### PR TITLE
Display

### DIFF
--- a/bolt/display.py
+++ b/bolt/display.py
@@ -196,3 +196,5 @@ class DisplayArrayJoint(object):
         self.fig2.ax.set_ylim([ybound, -0.2*ybound])
         self.fig1.ax.set_xlim([0, xbound])
         self.fig2.ax.set_xlim([0, xbound])
+
+        return self

--- a/bolt/display.py
+++ b/bolt/display.py
@@ -45,7 +45,7 @@ class DisplayArray(object):
         rect = Rectangle((x, y), width, height, fill=True, color=color, ec='white', lw=5)
         self.ax.add_patch(rect)
 
-    def draw(self, shape, cmap=None, scaleby=None, normby=None, label=True):
+    def draw(self, shape, cmap='Oranges', scaleby=None, normby=None, label=True):
         """
         Draw a sequence of rectangles representing an array shape.
 
@@ -66,8 +66,8 @@ class DisplayArray(object):
         label : boolean, optional, default=True
             Whether to add a text label with shape
         """
-        if cmap is None:
-            cmap = LinearSegmentedColormap.from_list('blend', ["#E6550D", "#FDD0A2"])
+        clrs = {'Oranges': LinearSegmentedColormap.from_list('blend', ["#E6550D", "#FDD0A2"]),
+                'Purples': LinearSegmentedColormap.from_list('blend', ["#393B79", "#9C9EDE"])}
 
         sizes, orient, scale = self.init(shape, normby)
         scale = scale * scaleby if scaleby is not None else scale
@@ -75,7 +75,7 @@ class DisplayArray(object):
 
         for i, s in enumerate(sizes):
             shift = s * scale
-            clr = cmap(i/float(len(sizes)))
+            clr = clrs[cmap](i/float(len(sizes)))
             if orient[i] == 0:
                 width, height = (shift, scale)
             else:
@@ -179,9 +179,8 @@ class DisplayArrayJoint(object):
             factor1, factor2 = (scale2/scale1, 1)
 
         # create the two displays
-        cmap = LinearSegmentedColormap.from_list('blend', ["#393B79", "#9C9EDE"])
-        self.fig1.draw(shape1, scaleby=factor1, normby=allmin, label=False)
-        self.fig2.draw(shape2, cmap=cmap, scaleby=factor2, normby=allmin, label=False)
+        self.fig1.draw(shape1, cmap='Oranges', scaleby=factor1, normby=allmin, label=False)
+        self.fig2.draw(shape2, cmap='Purples', scaleby=factor2, normby=allmin, label=False)
 
         # get common axis bounds
         ybound = max(self.fig1.ymax, self.fig2.ymax)

--- a/bolt/display.py
+++ b/bolt/display.py
@@ -5,10 +5,14 @@ from matplotlib.pyplot import xlim, ylim, gca, figure, text, subplot
 
 
 class DisplayArray(object):
-
+    """
+    Depicts the shape of an ndarray as a sequence of rectangles
+    """
     def __init__(self, width=600, height=200, ax=None):
         self.width = width
         self.height = height
+        self.xmax = 0
+        self.ymax = 0
 
         if ax is None:
             self.fig = figure(figsize=(12, 6))
@@ -18,26 +22,55 @@ class DisplayArray(object):
             self.ax = ax
 
     def box(self, x, y, width, height, color):
+        """
+        Draw a box with the given dimensions.
+
+        Parameters
+        ----------
+        x : float
+            Lower left corner, x-coordinate
+
+        y : float
+            Lower left corner, y-coordinate
+
+        width : float
+            Width of box
+
+        height : float
+            Height of box
+
+        color : str or tuple
+            Fill color
+        """
         rect = Rectangle((x, y), width, height, fill=True, color=color, ec='white', lw=5)
         self.ax.add_patch(rect)
 
-    @staticmethod
-    def strformat(shape):
-        return (("%s x " * len(shape)) % shape)[:-3]
+    def draw(self, shape, cmap=None, scaleby=None, normby=None, label=True):
+        """
+        Draw a sequence of rectangles representing an array shape.
 
-    @staticmethod
-    def iseven(n):
-        if (n == 0) | (n % 2 == 0):
-            return 0
-        else:
-            return 1
+        Parameters
+        ----------
+        shape : tuple
+            The shape of the array to depict
 
-    def draw(self, shape, cmap=None):
+        cmap : colormap, optional, default=None
+            Colormap to use to color rectangles, will use a provided cmap if None
 
+        scaleby : float, optional, default=None
+            A factor by which to rescale sizes, useful if comparing two arrays
+
+        normby : float, optional, default=None
+            Dimension to normalize by, if None will use minimum
+
+        label : boolean, optional, default=True
+            Whether to add a text label with shape
+        """
         if cmap is None:
             cmap = LinearSegmentedColormap.from_list('blend', ["#E6550D", "#FDD0A2"])
 
-        sizes, orient, scale = self.init(shape)
+        sizes, orient, scale = self.init(shape, normby)
+        scale = scale * scaleby if scaleby is not None else scale
         left, above, xmax, ymax = (0, 0, 0, 0)
 
         for i, s in enumerate(sizes):
@@ -55,35 +88,51 @@ class DisplayArray(object):
             else:
                 above += height
 
-        text(0, -20, self.strformat(shape), fontsize=20)
+        if label is True:
+            self.ax.text(0, -0.1*ymax, self.stringify(shape), fontsize=20)
+            self.ax.set_ylim([ymax, -0.2*ymax])
+        else:
+            self.ax.set_ylim([ymax, 0])
 
         self.ax.set_aspect('equal')
         self.ax.axis('off')
         self.ax.set_xlim([0, xmax])
-        self.ax.set_ylim([ymax, -40])
         self.xmax = xmax
         self.ymax = ymax
 
         return self
 
-    def init(self, shape):
+    def init(self, shape, normby=None):
+        """
+        Initialize display parameters
 
+        Parameters
+        ----------
+        shape : tuple
+            Shape of the array
+
+        normby : float, optional, default=None
+            What to normalize by, if None will use minimum dimensions
+        """
         shape = asarray(shape, 'float')
         n = len(shape)
 
         # normalize dims to 1
-        shape /= shape.min()
+        normby = normby if normby is not None else shape.min()
+        shape /= normby
 
-        # set if boxes will be horzizontal vs vertical
-        orient = asarray(map(lambda x: self.iseven(x), range(n)))
+        # determine which boxes will be horzizontal vs vertical
+        orient = asarray([0 if i % 2 == 0 else 1 for i in range(n)])
+
+        # get dimensions of resulting grid
         ncol = sum(shape[orient == 0])
         nrow = sum(shape[orient == 1])
-
         if orient[-1] == 0:
             nrow += 1
         if orient[-1] == 1:
             ncol += 2
 
+        # automatically determine scale to fill space
         if ncol > nrow:
             scale = min([self.height / nrow, self.width / ncol])
         else:
@@ -91,26 +140,59 @@ class DisplayArray(object):
 
         return shape, orient, scale
 
+    @staticmethod
+    def stringify(shape):
+        return (("%s x " * len(shape)) % shape)[:-3]
+
 class DisplayArrayJoint(object):
 
     def __init__(self):
+        from matplotlib import gridspec
         self.fig = figure(figsize=(10, 5))
+        self.gs = gridspec.GridSpec(1, 2, width_ratios=[1, 1])
+        self.ax1 = subplot(self.gs[0])
+        self.fig1 = DisplayArray(ax=self.ax1)
+        self.ax2 = subplot(self.gs[1])
+        self.fig2 = DisplayArray(ax=self.ax2)
 
     def draw(self, shape1, shape2):
+        """
+        Draw rectangles representing two arrays shapes
 
+        Parameters
+        ----------
+        shape1 : tuple
+            The shape of the first array
+
+        shape2 : tuple
+            The shape of the second array
+        """
+        # get minimum across both sets of dimensions
+        allmin = min(min(list(shape1)), min(list(shape2)))
+
+        # estimate relative scaling
+        _, _, scale1 = self.fig1.init(shape1, normby=allmin)
+        _, _, scale2 = self.fig2.init(shape2, normby=allmin)
+        if scale1 > scale2:
+            factor1, factor2 = (1, scale1/scale2)
+        else:
+            factor1, factor2 = (scale2/scale1, 1)
+
+        # create the two displays
         cmap = LinearSegmentedColormap.from_list('blend', ["#393B79", "#9C9EDE"])
+        self.fig1.draw(shape1, scaleby=factor1, normby=allmin, label=False)
+        self.fig2.draw(shape2, cmap=cmap, scaleby=factor2, normby=allmin, label=False)
 
-        from matplotlib import gridspec
-        gs = gridspec.GridSpec(1, 2, width_ratios=[1, 1])
-        ax0 = subplot(gs[0])
-        fig1 = DisplayArray(ax=ax0).draw(shape1)
-        ax1 = subplot(gs[1])
-        fig2 = DisplayArray(ax=ax1).draw(shape2, cmap=cmap)
+        # get common axis bounds
+        ybound = max(self.fig1.ymax, self.fig2.ymax)
+        xbound = max(self.fig1.xmax, self.fig2.xmax)
 
-        ybound = max(fig1.ymax, fig2.ymax)
-        fig1.ax.set_ylim([ybound, -40])
-        fig2.ax.set_ylim([ybound, -40])
+        # add text labels
+        self.fig1.ax.text(0, -0.1*ybound, DisplayArray.stringify(shape1), fontsize=20)
+        self.fig2.ax.text(0, -0.1*ybound, DisplayArray.stringify(shape2), fontsize=20)
 
-        gs.set_width_ratios(([fig1.xmax / fig2.xmax, 1]))
-
-        self.fig.tight_layout()
+        # set limits
+        self.fig1.ax.set_ylim([ybound, -0.2*ybound])
+        self.fig2.ax.set_ylim([ybound, -0.2*ybound])
+        self.fig1.ax.set_xlim([0, xbound])
+        self.fig2.ax.set_xlim([0, xbound])

--- a/bolt/display.py
+++ b/bolt/display.py
@@ -1,0 +1,138 @@
+from numpy import asarray, hstack, arange
+from matplotlib.patches import Rectangle
+from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.pyplot import xlim, ylim, gca, axis, figure, text
+
+
+class DisplayArray(object):
+
+    def __init__(self, width=600, height=200):
+        self.width = width
+        self.height = height
+
+        fig = figure(figsize=(12, 6))
+        self.fig = fig
+        self.ax = gca()
+
+    def horzbox(self, x, y, width, scale, color):
+        rect = Rectangle((x, y), width, scale, fill=True, color=color, ec='white', lw=5)
+        self.ax.add_patch(rect)
+        self.updatebounds(x + width, y + scale)
+
+    def vertbox(self, x, y, height, scale, color):
+        rect = Rectangle((x, y), scale, height, fill=True, color=color, ec='white', lw=5)
+        self.ax.add_patch(rect)
+        self.updatebounds(x + scale, y + height)
+
+    def updatebounds(self, x, y):
+        self.xmax = max(self.xmax, x)
+        self.ymax = max(self.ymax, y)
+
+    @staticmethod
+    def strformat(shape):
+        return (("%s x " * len(shape)) % (shape))[:-3]
+
+    @staticmethod
+    def iseven(n):
+        if (n == 0) | (n % 2 == 0):
+            return 0
+        else:
+            return 1
+
+    def draw(self, shape1, shape2):
+
+        self.init(shape1, shape2)
+
+        left = 0
+        above = 0
+
+        if len(shape1) > 0:
+            text(0, -20, self.strformat(shape1), fontsize=20)
+        elif len(shape2) > 0:
+            text(0, -20, self.strformat(shape2), fontsize=20)
+
+        for i, s in enumerate(self.shape):
+            shift = s * self.scale
+            if i >= len(shape1):
+                clr = self.cmap1(self.count[i]/float(len(shape2) + 0.1))
+            else:
+                clr = self.cmap2(self.count[i]/float(len(shape1) + 0.1))
+            if self.pos[i] == 0:
+                self.horzbox(left, above, shift, self.scale, clr)
+                left += shift
+            else:
+                self.vertbox(left, above, shift, self.scale, clr)
+                above += shift
+
+            if i < (len(self.shape) - 1):
+                if self.count[i+1] == 0:
+                    if self.pos[i] == 0:
+                        left += self.scale
+                    else:
+                        left += self.scale * 2
+                    above = 0
+                    text(left, -20, self.strformat(shape2), fontsize=20)
+
+        self.ax.set_aspect('equal')
+        xlim([0, self.xmax])
+        ylim([self.ymax, -40])
+
+    def init(self, shape1, shape2):
+
+        shape1 = asarray(shape1, 'float')
+        shape2 = asarray(shape2, 'float')
+
+        n = len(shape1)
+        m = len(shape2)
+
+        rescale = min(hstack((shape1, shape2)))
+        shape1 = shape1 / rescale
+        shape2 = shape2 / rescale
+
+        pos1 = asarray(map(lambda x: self.iseven(x), range(n)))
+        pos2 = asarray(map(lambda x: self.iseven(x), range(m)))
+
+        depth1 = sum(shape1[pos1 == 1])
+        depth2 = sum(shape2[pos2 == 1])
+
+        shape = hstack((shape1, shape2))
+        pos = hstack((pos1, pos2))
+        count = hstack((arange(n), arange(m)))
+
+        ncol = sum(shape[pos == 0])
+        nrow = max(depth1, depth2)
+
+        if len(shape1) > 0:
+            if pos1[-1] == 0:
+                ncol += 1
+            if pos1[-1] == 1:
+                ncol += 2
+            if pos1[-1] == 1:
+                ncol += 1
+
+        if len(shape2) > 0:
+            if pos2[-1] == 1:
+                ncol += 1
+
+        if len(shape1) > 0 and len(shape2) > 0:
+            if depth1 > depth2:
+                if pos1[-1] == 0:
+                    nrow += 1
+            else:
+                if pos2[-1] == 0:
+                    nrow += 1
+
+        if ncol > nrow:
+            scale = min([self.height / nrow, self.width / ncol])
+        else:
+            scale = self.height / nrow
+
+        self.shape = shape
+        self.pos = pos
+        self.count = count
+        self.scale = scale
+        self.xmax = 0
+        self.ymax = 0
+        self.cmap1 = LinearSegmentedColormap.from_list('blend', ["#393B79", "#9C9EDE"])
+        self.cmap2 = LinearSegmentedColormap.from_list('blend', ["#E6550D", "#FDD0A2"])
+

--- a/bolt/local.py
+++ b/bolt/local.py
@@ -48,3 +48,7 @@ class BoltArrayLocal(ndarray, BoltArray):
 
     def __repr__(self):
         return BoltArray.__repr__(self)
+
+    def layout(self):
+        from bolt.display import DisplayArray
+        DisplayArray().draw(self.shape, ())

--- a/bolt/local.py
+++ b/bolt/local.py
@@ -51,4 +51,4 @@ class BoltArrayLocal(ndarray, BoltArray):
 
     def layout(self):
         from bolt.display import DisplayArray
-        DisplayArray().draw(self.shape, ())
+        DisplayArray().draw(self.shape)

--- a/bolt/spark.py
+++ b/bolt/spark.py
@@ -253,5 +253,11 @@ class BoltArraySpark(BoltArray):
             print x
 
     def layout(self):
-        from bolt.display import DisplayArrayJoint
-        DisplayArrayJoint().draw(self.keys.shape, self.values.shape)
+        from bolt.display import DisplayArray, DisplayArrayJoint
+        if len(self.keys.shape) > 0 and len(self.values.shape):
+            DisplayArrayJoint().draw(self.keys.shape, self.values.shape)
+        else:
+            if len(self.keys.shape):
+                DisplayArray().draw(self.keys.shape, cmap='Purples')
+            else:
+                DisplayArray().draw(self.values.shape, cmap='Oranges')

--- a/bolt/spark.py
+++ b/bolt/spark.py
@@ -252,5 +252,5 @@ class BoltArraySpark(BoltArray):
         return str(asarray(self._rdd.take(10)))
 
     def layout(self):
-        from bolt.display import DisplayArray
-        DisplayArray().draw(self.keys.shape, self.values.shape)
+        from bolt.display import DisplayArrayJoint
+        DisplayArrayJoint().draw(self.keys.shape, self.values.shape)

--- a/bolt/spark.py
+++ b/bolt/spark.py
@@ -250,3 +250,7 @@ class BoltArraySpark(BoltArray):
 
     def display(self):
         return str(asarray(self._rdd.take(10)))
+
+    def layout(self):
+        from bolt.display import DisplayArray
+        DisplayArray().draw(self.keys.shape, self.values.shape)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
+matplotlib
 findspark


### PR DESCRIPTION
This PR adds support for a simple graphical depiction of the layout of bolt arrays, displayed upon calling `array.layout()`. These graphics provide compact information about the shape of the array, and in the case of distributed arrays, the shape of the "keys" and the "values". I've found them useful while making changes to the structure of the array. And we can add other functionality (e.g. stripes in a subset of rectangles to imply if and where arrays have been chunked).

![image](https://cloud.githubusercontent.com/assets/3387500/8398232/50cd1b86-1db4-11e5-95e3-d8755d5e01bf.png)
![image](https://cloud.githubusercontent.com/assets/3387500/8398234/55db01f6-1db4-11e5-8174-98edfa1cf6b0.png)
![image](https://cloud.githubusercontent.com/assets/3387500/8398235/5c65a486-1db4-11e5-94d0-eb73a6294209.png)

