### PR TITLE
argpack bug fix

### DIFF
--- a/bolt/utils.py
+++ b/bolt/utils.py
@@ -25,8 +25,8 @@ def argpack(args):
     args : tuple or nested tuple
         Pack arguments into a tuple, converting ((,...),) or (,) -> (,)
     """
-    if isinstance(args[0], tuple):
-        return args[0]
+    if isinstance(args[0], (tuple, list, ndarray)):
+        return tupleize(args[0])
     else:
         return tuple(args)
 


### PR DESCRIPTION
`argpack` now also recognizes lists and ndarrays (in addition to tuples) as special cases to not try to pack. This bug was previously causing tests to fail.

NB: I should have named the branch `argpack-fix` instead of `argsort-fix` as that is where the problem and solution were.
