### PR TITLE
Swap bugfix

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -378,7 +378,7 @@ class BoltArraySpark(BoltArray):
 
         key_axes, value_axes = tupleize(key_axes), tupleize(value_axes)
 
-        if len(key_axes) == self.keys.shape:
+        if len(key_axes) == self.keys.ndim:
             raise ValueError('Cannot perform a swap that would '
                              'end up with all data on a single key')
 

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from numpy import asarray, unravel_index, prod, mod, ndarray, ceil, where, r_, sort, argsort
+from numpy import asarray, unravel_index, prod, mod, ndarray, ceil, where, r_, sort, argsort, array
 from itertools import groupby
 
 from bolt.base import BoltArray
@@ -378,23 +378,35 @@ class BoltArraySpark(BoltArray):
 
         key_axes, value_axes = tupleize(key_axes), tupleize(value_axes)
 
-        if len(key_axes) == self.keys.ndim:
+        if len(key_axes) == self.keys.ndim and len(value_axes) == 0:
             raise ValueError('Cannot perform a swap that would '
                              'end up with all data on a single key')
 
         if len(key_axes) == 0 and len(value_axes) == 0:
             return self
 
+        if self.values.ndim == 0:
+            rdd = self._rdd.mapValues(lambda v: array(v, ndmin=1))
+            value_shape = (1,)
+        else:
+            rdd = self._rdd
+            value_shape = self.values.shape
+
         from bolt.spark.swap import Swapper, Dims
 
         k = Dims(shape=self.keys.shape, axes=key_axes)
-        v = Dims(shape=self.values.shape, axes=value_axes)
+        v = Dims(shape=value_shape, axes=value_axes)
         s = Swapper(k, v, self.dtype, size)
 
-        chunks = s.chunk(self._rdd)
+        chunks = s.chunk(rdd)
         rdd = s.extract(chunks)
+
         shape = s.getshape()
         split = self.split - len(key_axes) + len(value_axes)
+
+        if self.values.ndim == 0:
+            rdd = rdd.mapValues(lambda v: v.squeeze())
+            shape = shape[:-1]
 
         return self._constructor(rdd, shape=tuple(shape), split=split)
 

--- a/bolt/spark/swap.py
+++ b/bolt/spark/swap.py
@@ -20,7 +20,7 @@ class Swapper(object):
         Get resulting shape after swapping
         """
         return r_[self.key.shape[~self.key.mask], self.value.shape[self.value.mask],
-                  self.key.shape[self.key.mask], self.value.shape[~self.value.mask]]
+                  self.key.shape[self.key.mask], self.value.shape[~self.value.mask]].astype('int')
 
     def chunk(self, rdd):
         """
@@ -39,6 +39,7 @@ class Swapper(object):
             for (chk, slc) in scheme:
                 k = (tuple(asarray(chk)[vmask]), stationary)
                 yield k, (moving, v[slc])
+                #yield k, (moving, v, slc)
 
         return rdd.flatMap(_chunk).groupByKey()
 

--- a/test/spark/test_spark_shaping.py
+++ b/test/spark/test_spark_shaping.py
@@ -180,6 +180,13 @@ def test_swap(sc):
     assert allclose(at, bs.toarray())
     assert bs.split == 3
 
+    b = array(a, sc, axes=range(8))
+    bs = b.swap([0,1], [])
+    at = a.transpose((2, 3, 4, 5, 6, 7, 0, 1))
+    assert allclose(at, bs.toarray())
+    assert bs.split == 6
+
+
 def test_transpose(sc):
 
     n = 4


### PR DESCRIPTION
There was a problem with `swap`: when all of the dimensions were in the keys, the algorithm could not handle the non-array singleton values.

This is fixed by effectively adding a dummy dimension at the beginning of the swap and then removing it again at the end.