### PR TITLE
Assorted bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ BoltArray
 mode: spark
 shape: (2, 3, 3)
 ```
-And all operations will distributed, including both ndarray operations (`mean`, `max`, `squeeze`), functional operators (`map`, `reduce`, `filter`), shaping (`reshape`, `transpose`), and slicing / indexing.
+And all operations will be distributed, including both ndarray operations (`mean`, `max`, `squeeze`), functional operators (`map`, `reduce`, `filter`), shaping (`reshape`, `transpose`), and slicing / indexing.
 ```
 >> y.filter(lambda x: sum(x) > 50)
 BoltArray

--- a/bolt/local/array.py
+++ b/bolt/local/array.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from numpy import ndarray, asarray, ufunc, prod
 from bolt.base import BoltArray
-from bolt.utils import check_axes
+from bolt.utils import check_axes, tupleize
 from functools import reduce
 
 
@@ -40,21 +40,21 @@ class BoltArrayLocal(ndarray, BoltArray):
 
         return reshaped
 
-    def filter(self, func, axes=(0,)):
+    def filter(self, func, axis=0):
         """
         """
-        axes = sorted(axes)
+        axes = sorted(tupleize(axis))
         reshaped = self._configure_axes(axes)
 
         filtered = asarray(list(filter(func, reshaped)))
 
         return self._constructor(filtered)
 
-    def map(self, func, axes=(0,)):
+    def map(self, func, axis=0):
         """
         """
 
-        axes = sorted(axes)
+        axes = sorted(tupleize(axis))
         key_shape = [self.shape[axis] for axis in axes]
         reshaped = self._configure_axes(axes, key_shape=key_shape)
 
@@ -67,11 +67,11 @@ class BoltArrayLocal(ndarray, BoltArray):
 
         return self._constructor(reordered)
 
-    def reduce(self, func, axes=(0,)):
+    def reduce(self, func, axis=0):
         """
         """
 
-        axes = sorted(axes)
+        axes = sorted(tupleize(axis))
 
         # if the function is a ufunc, it can automatically handle reducing over multiple axes
         if isinstance(func, ufunc):
@@ -97,13 +97,13 @@ class BoltArrayLocal(ndarray, BoltArray):
         else:
             raise ValueError("other must be local array, got %s" % type(arry))
 
-    def tospark(self, sc, axes=(0,)):
+    def tospark(self, sc, axis=0):
         from bolt import array
-        return array(self.toarray(), sc, axes=axes)
+        return array(self.toarray(), sc, axis=axis)
 
-    def tordd(self, sc, axes=(0,)):
+    def tordd(self, sc, axis=0):
         from bolt import array
-        return array(self.toarray(), sc, axes=axes).tordd()
+        return array(self.toarray(), sc, axis=axis).tordd()
 
     def toarray(self):
         return asarray(self)

--- a/bolt/spark/construct.py
+++ b/bolt/spark/construct.py
@@ -10,7 +10,7 @@ from bolt.spark.utils import get_kv_shape, get_kv_axes
 class ConstructSpark(ConstructBase):
 
     @staticmethod
-    def array(a, context=None, axes=(0,), dtype=None):
+    def array(a, context=None, axis=(0,), dtype=None):
         """
         Create a spark bolt array from a local array.
 
@@ -24,7 +24,7 @@ class ConstructSpark(ConstructBase):
         context : SparkContext
             A context running Spark. (see pyspark)
 
-        axes : tuple, optional, default=(0,)
+        axis : tuple, optional, default=(0,)
             Which axes to distribute the array along. The resulting
             distributed object will use keys to represent these axes,
             with the remaining axes represented by values.
@@ -46,7 +46,7 @@ class ConstructSpark(ConstructBase):
         ndim = len(shape)
 
         # handle the axes specification and transpose if necessary
-        axes = ConstructSpark._format_axes(axes, arry.shape)
+        axes = ConstructSpark._format_axes(axis, arry.shape)
         key_axes, value_axes = get_kv_axes(arry.shape, axes)
         permutation = key_axes + value_axes
         arry = arry.transpose(*permutation)
@@ -67,7 +67,7 @@ class ConstructSpark(ConstructBase):
         return BoltArraySpark(rdd, shape=shape, split=split, dtype=dtype)
 
     @staticmethod
-    def ones(shape, context=None, axes=(0,), dtype=float64):
+    def ones(shape, context=None, axis=(0,), dtype=float64):
         """
         Create a spark bolt array of ones.
 
@@ -79,7 +79,7 @@ class ConstructSpark(ConstructBase):
         context : SparkContext
             A context running Spark. (see pyspark)
 
-        axes : tuple, optional, default=(0,)
+        axis : tuple, optional, default=(0,)
             Which axes to distribute the array along. The resulting
             distributed object will use keys to represent these axes,
             with the remaining axes represented by values.
@@ -93,10 +93,10 @@ class ConstructSpark(ConstructBase):
         BoltArraySpark
         """
         from numpy import ones
-        return ConstructSpark._wrap(ones, shape, context, axes, dtype)
+        return ConstructSpark._wrap(ones, shape, context, axis, dtype)
 
     @staticmethod
-    def zeros(shape, context=None, axes=(0,), dtype=float64):
+    def zeros(shape, context=None, axis=(0,), dtype=float64):
         """
         Create a spark bolt array of zeros.
 
@@ -108,7 +108,7 @@ class ConstructSpark(ConstructBase):
         context : SparkContext
             A context running Spark. (see pyspark)
 
-        axes : tuple, optional, default=(0,)
+        axis : tuple, optional, default=(0,)
             Which axes to distribute the array along. The resulting
             distributed object will use keys to represent these axes,
             with the remaining axes represented by values.
@@ -122,7 +122,7 @@ class ConstructSpark(ConstructBase):
         BoltArraySpark
         """
         from numpy import zeros
-        return ConstructSpark._wrap(zeros, shape, context, axes, dtype)
+        return ConstructSpark._wrap(zeros, shape, context, axis, dtype)
 
     @staticmethod
     def concatenate(arrays, axis=0):
@@ -196,13 +196,13 @@ class ConstructSpark(ConstructBase):
         return axes
 
     @staticmethod
-    def _wrap(func, shape, context=None, axes=(0,), dtype=None):
+    def _wrap(func, shape, context=None, axis=(0,), dtype=None):
         """
         Wrap an existing numpy constructor in a parallelized construction
         """
         if isinstance(shape, int):
             shape = (shape,)
-        key_shape, value_shape = get_kv_shape(shape, ConstructSpark._format_axes(axes, shape))
+        key_shape, value_shape = get_kv_shape(shape, ConstructSpark._format_axes(axis, shape))
         split = len(key_shape)
 
         # make the keys

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 numpy
-findspark

--- a/test/generic.py
+++ b/test/generic.py
@@ -21,25 +21,30 @@ def map_suite(arr, b):
     import random
     random.seed(42)
 
-    # A simple map should be equivalent to an element-wise multiplication
+    # a simple map should be equivalent to an element-wise multiplication (without axis specified)
     func1 = lambda x: x * 2
-    mapped = b.map(func1, axes=(0,))
+    mapped = b.map(func1)
     res = mapped.toarray()
-    print("res.shape: %s" % str(res.shape))
     assert allclose(res, arr * 2)
 
-    # More complicated maps can reshape elements so long as they do so consistently
+    # a simple map should be equivalent to an element-wise multiplication (with axis specified)
+    func1 = lambda x: x * 2
+    mapped = b.map(func1, axis=0)
+    res = mapped.toarray()
+    assert allclose(res, arr * 2)
+
+    # more complicated maps can reshape elements so long as they do so consistently
     func2 = lambda x: ones(10)
-    mapped = b.map(func2, axes=(0,))
+    mapped = b.map(func2, axis=0)
     res = mapped.toarray()
     assert res.shape == (arr.shape[0], 10)
 
-    # But the shape of the result will change if mapped over different axes
-    mapped = b.map(func2, axes=(0,1))
+    # but the shape of the result will change if mapped over different axes
+    mapped = b.map(func2, axis=(0, 1))
     res = mapped.toarray()
     assert res.shape == (arr.shape[0], arr.shape[1], 10)
 
-    # If a map is not applied uniformly, it should produce an error
+    # if a map is not applied uniformly, it should produce an error
     with pytest.raises(Exception):
         def nonuniform_map(x):
             random.seed(x.tostring())
@@ -64,13 +69,13 @@ def reduce_suite(arr, b):
     from operator import add
 
     # Reduce over the first axis with an add
-    reduced = b.reduce(add, axes=(0,))
+    reduced = b.reduce(add, axis=0)
     res = reduced.toarray()
     assert res.shape == (arr.shape[1], arr.shape[2])
     assert allclose(res, sum(arr, 0))
 
     # Reduce over multiple axes with an add
-    reduced = b.reduce(add, axes=(0, 1))
+    reduced = b.reduce(add, axis=(0, 1))
     res = reduced.toarray()
     assert res.shape == (arr.shape[2],)
     assert allclose(res, sum(sum(arr, 0), 1))

--- a/test/local/test_local_basic.py
+++ b/test/local/test_local_basic.py
@@ -20,7 +20,7 @@ def test_tospark(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
     b = array(x)
-    s = b.tospark(sc, axes=(0,))
+    s = b.tospark(sc, axis=0)
     assert isinstance(s, BoltArraySpark)
     assert s.shape == (2, 3, 4)
     assert allclose(s.toarray(), x)
@@ -31,14 +31,14 @@ def test_tordd(sc):
     x = arange(2*3*4).reshape((2, 3, 4))
 
     b = array(x)
-    r = b.tordd(sc, axes=(0,))
+    r = b.tordd(sc, axis=0)
     assert isinstance(r, RDD)
     assert r.count() == 2
 
-    r = b.tordd(sc, axes=(0, 1))
+    r = b.tordd(sc, axis=(0, 1))
     assert isinstance(r, RDD)
     assert r.count() == 2*3
 
-    r = b.tordd(sc, axes=(0, 1, 2))
+    r = b.tordd(sc, axis=(0, 1, 2))
     assert isinstance(r, RDD)
     assert r.count() == 2*3*4

--- a/test/spark/test_spark_basic.py
+++ b/test/spark/test_spark_basic.py
@@ -15,22 +15,22 @@ def test_shape(sc):
 def test_size(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     assert b.size == x.size
 
 def test_split(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     assert b.split == 1
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     assert b.split == 2
 
 def test_ndim(sc):
 
     x = arange(2**5).reshape(2, 2, 2, 2, 2)
-    b = array(x, sc, axes=[0, 1, 2])
+    b = array(x, sc, axis=(0, 1, 2))
 
     assert b.keys.ndim == 3
     assert b.values.ndim == 2
@@ -39,13 +39,13 @@ def test_ndim(sc):
 def test_mask(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     assert b.mask == (1, 0, 0)
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     assert b.mask == (1, 1, 0)
 
-    b = array(x, sc, axes=(0, 1, 2))
+    b = array(x, sc, axis=(0, 1, 2))
     assert b.mask == (1, 1, 1)
 
 def test_cache(sc):

--- a/test/spark/test_spark_construct.py
+++ b/test/spark/test_spark_construct.py
@@ -12,11 +12,11 @@ def test_array(sc):
     assert isinstance(b, BoltArraySpark)
     assert allclose(x, b.toarray())
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     assert isinstance(b, BoltArraySpark)
     assert allclose(x, b.toarray())
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     assert isinstance(b, BoltArraySpark)
     assert allclose(x, b.toarray())
 
@@ -25,10 +25,10 @@ def test_array_errors(sc):
     x = arange(2*3*4).reshape((2, 3, 4))
 
     with pytest.raises(ValueError):
-        array(x, sc, axes=(-1,))
+        array(x, sc, axis=-1)
 
     with pytest.raises(ValueError):
-        array(x, sc, axes=(0, 1, 2, 3))
+        array(x, sc, axis=(0, 1, 2, 3))
 
 def test_ones(sc):
 
@@ -57,7 +57,7 @@ def test_concatenate(sc):
     from numpy import concatenate as npconcatenate
     x = arange(2*3*4).reshape((2, 3, 4))
 
-    b = array(x, sc, axes=0)
+    b = array(x, sc, axis=0)
     bb = concatenate((b, b), axis=0)
     assert allclose(npconcatenate((x, x), axis=0), bb.toarray())
 
@@ -67,22 +67,22 @@ def test_concatenate(sc):
     bb = concatenate((b, b), axis=2)
     assert allclose(npconcatenate((x, x), axis=2), bb.toarray())
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     bb = concatenate((b, b), axis=0)
     assert allclose(npconcatenate((x, x), axis=0), bb.toarray())
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     bb = concatenate((b, b), axis=1)
     assert allclose(npconcatenate((x, x), axis=1), bb.toarray())
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     bb = concatenate((b, b), axis=2)
     assert allclose(npconcatenate((x, x), axis=2), bb.toarray())
 
 def test_concatenate_errors(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
-    b = array(x, sc, axes=0)
+    b = array(x, sc, axis=0)
 
     with pytest.raises(ValueError):
         concatenate(b)

--- a/test/spark/test_spark_functional.py
+++ b/test/spark/test_spark_functional.py
@@ -10,14 +10,19 @@ def test_map(sc):
     random.seed(42)
 
     x = arange(2*3*4).reshape(2, 3, 4)
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
 
     # Test all map functionality when the base array is split after the first axis
     generic.map_suite(x, b)
 
     # Split the BoltArraySpark after the second axis and rerun the tests
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     generic.map_suite(x, b)
+
+    # Split the BoltArraySpark after the third axis (scalar values) and rerun the tests
+    #b = array(x, sc, axis=(0, 1, 2))
+    #generic.map_suite(x, b)
+
 
 def test_reduce(sc):
 
@@ -26,71 +31,86 @@ def test_reduce(sc):
     dims = (10, 10, 10)
     area = dims[0] * dims[1]
     arr = asarray([repeat(x, area).reshape(dims[0], dims[1]) for x in range(dims[2])])
-    b = array(arr, sc, axes=(0,))
+    b = array(arr, sc, axis=0)
 
     # Test all reduce functionality when the base array is split after the first axis
     generic.reduce_suite(arr, b)
 
     # Split the BoltArraySpark after the second axis and rerun the tests
-    b = array(arr, sc, axes=(0, 1))
+    b = array(arr, sc, axis=(0, 1))
     generic.reduce_suite(arr, b)
+
+    # Split the BoltArraySpark after the third axis (scalar values) and rerun the tests
+    #b = array(arr, sc, axis=(0, 1, 2))
+    #generic.reduce_suite(arr, b)
+
 
 def test_filter(sc):
 
     x = arange(2*3*4).reshape(2, 3, 4)
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
 
     # Test all filter functionality when the base array is split after the first axis
     generic.filter_suite(x, b)
 
     # Split the BoltArraySpark after the second axis and rerun the tests
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     generic.filter_suite(x, b)
+
+    # Split the BoltArraySpark after the third axis (scalar values) and rerun the tests
+    #b = array(x, sc, axis=(0, 1, 2))
+    #generic.filter_suite(x, b)
 
 def test_mean(sc):
     x = arange(2*3*4).reshape(2, 3, 4)
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=(0,))
 
-    assert allclose(b.mean(axes=(0,)), x.mean(axis=(0,)))
-    assert allclose(b.mean(axes=(0,1)), x.mean(axis=(0, 1)))
-    assert b.mean(axes=(0, 1, 2)) == x.mean(axis=(0, 1, 2))
+    assert allclose(b.mean(), x.mean())
+    assert allclose(b.mean(axis=0), x.mean(axis=0))
+    assert allclose(b.mean(axis=(0, 1)), x.mean(axis=(0, 1)))
+    assert b.mean(axis=(0, 1, 2)) == x.mean(axis=(0, 1, 2))
 
 def test_std(sc):
     x = arange(2*3*4).reshape(2, 3, 4)
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=(0,))
 
-    assert allclose(b.std(axes=(0,)), x.std(axis=(0,)))
-    assert allclose(b.std(axes=(0,1)), x.std(axis=(0, 1)))
-    assert b.std(axes=(0, 1, 2)) == x.std(axis=(0, 1, 2))
+    assert allclose(b.std(), x.std())
+    assert allclose(b.std(axis=0), x.std(axis=0))
+    assert allclose(b.std(axis=(0, 1)), x.std(axis=(0, 1)))
+    assert b.std(axis=(0, 1, 2)) == x.std(axis=(0, 1, 2))
 
 def test_var(sc):
     x = arange(2*3*4).reshape(2, 3, 4)
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=(0,))
 
-    assert allclose(b.var(axes=(0,)), x.var(axis=(0,)))
-    assert allclose(b.var(axes=(0,1)), x.var(axis=(0, 1)))
-    assert b.var(axes=(0,1,2)) == x.var(axis=(0, 1, 2))
+    assert allclose(b.var(), x.var())
+    assert allclose(b.var(axis=0), x.var(axis=0))
+    assert allclose(b.var(axis=(0, 1)), x.var(axis=(0, 1)))
+    assert b.var(axis=(0,1,2)) == x.var(axis=(0, 1, 2))
 
 def test_sum(sc):
     x = arange(2*3*4).reshape(2, 3, 4)
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=(0,))
 
-    assert allclose(b.sum(axes=(0,)), x.sum(axis=(0,)))
-    assert allclose(b.sum(axes=(0,1)), x.sum(axis=(0,1)))
-    assert b.sum(axes=(0, 1, 2)) == x.sum(axis=(0, 1, 2))
+    assert allclose(b.sum(), x.sum())
+    assert allclose(b.sum(axis=0), x.sum(axis=0))
+    assert allclose(b.sum(axis=(0, 1)), x.sum(axis=(0,1)))
+    assert b.sum(axis=(0, 1, 2)) == x.sum(axis=(0, 1, 2))
 
 def test_min(sc):
     x = arange(2*3*4).reshape(2, 3, 4)
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=(0,))
 
-    assert allclose(b.min(axes=(0,)), x.min(axis=(0,)))
-    assert allclose(b.min(axes=(0,1)), x.min(axis=(0, 1)))
-    assert b.min(axes=(0, 1, 2)) == x.min(axis=(0, 1, 2))
+    assert allclose(b.min(), x.min())
+    assert allclose(b.min(axis=0), x.min(axis=0))
+    assert allclose(b.min(axis=(0, 1)), x.min(axis=(0, 1)))
+    assert b.min(axis=(0, 1, 2)) == x.min(axis=(0, 1, 2))
 
 def test_max(sc):
     x = arange(2*3*4).reshape(2, 3, 4)
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=(0,))
 
-    assert allclose(b.max(axes=(0,)), x.max(axis=(0,)))
-    assert allclose(b.max(axes=(0,1)), x.max(axis=(0, 1)))
-    assert b.max(axes=(0, 1, 2)) == x.max(axis=(0, 1, 2))
+    assert allclose(b.max(), x.max())
+    assert allclose(b.max(axis=0), x.max(axis=0))
+    assert allclose(b.max(axis=(0, 1)), x.max(axis=(0, 1)))
+    assert b.max(axis=(0, 1, 2)) == x.max(axis=(0, 1, 2))

--- a/test/spark/test_spark_getting.py
+++ b/test/spark/test_spark_getting.py
@@ -6,7 +6,7 @@ from bolt.utils import allclose
 def test_getitem_slice(sc):
     x = arange(2*3).reshape((2, 3))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     assert allclose(b[0:1, 0:1].toarray(), x[0:1, 0:1])
     assert allclose(b[0:2, 0:2].toarray(), x[0:2, 0:2])
     assert allclose(b[0:2, 0:3].toarray(), x[0:2, 0:3])
@@ -14,7 +14,7 @@ def test_getitem_slice(sc):
     assert allclose(b[:2, :2].toarray(), x[:2, :2])
     assert allclose(b[1:, 1:].toarray(), x[1:, 1:])
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     assert allclose(b[0:1, 0:1].toarray(), x[0:1, 0:1])
     assert allclose(b[0:2, 0:2].toarray(), x[0:2, 0:2])
     assert allclose(b[0:2, 0:3].toarray(), x[0:2, 0:3])
@@ -26,7 +26,7 @@ def test_getitem_slice_ragged(sc):
 
     x = arange(10*10*3).reshape((10, 10, 3))
 
-    b = array(x, sc, axes=(0,1))
+    b = array(x, sc, axis=(0,1))
     assert allclose(b[0:5:2, 0:2].toarray(), x[0:5:2, 0:2])
     assert allclose(b[0:5:3, 0:2].toarray(), x[0:5:3, 0:2])
     assert allclose(b[0:9:3, 0:2].toarray(), x[0:9:3, 0:2])
@@ -35,7 +35,7 @@ def test_getitem_int(sc):
 
     x = arange(2*3).reshape((2, 3))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     assert allclose(b[0, 0], x[0, 0])
     assert allclose(b[0, 1], x[0, 1])
     assert allclose(b[0, 0:1], x[0, 0:1])
@@ -43,7 +43,7 @@ def test_getitem_int(sc):
     assert allclose(b[[1], [2]].toarray(), x[[1], [2]])
     assert allclose(b[[1], 2].toarray(), x[[1], 2])
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     assert allclose(b[0, 0], x[0, 0])
     assert allclose(b[0, 1], x[0, 1])
     assert allclose(b[0, 0:1], x[0, 0:1])
@@ -55,12 +55,12 @@ def test_getitem_list(sc):
 
     x = arange(3*3*4).reshape((3, 3, 4))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     assert allclose(b[[0, 1], [0, 1], [0, 2]].toarray(), x[[0, 1], [0, 1], [0, 2]])
     assert allclose(b[[0, 1], [0, 2], [0, 3]].toarray(), x[[0, 1], [0, 2], [0, 3]])
     assert allclose(b[[0, 1, 2], [0, 2, 1], [0, 3, 1]].toarray(), x[[0, 1, 2], [0, 2, 1], [0, 3, 1]])
 
-    b = array(x, sc, axes=(0,1))
+    b = array(x, sc, axis=(0,1))
     assert allclose(b[[0, 1], [0, 1], [0, 2]].toarray(), x[[0, 1], [0, 1], [0, 2]])
     assert allclose(b[[0, 1], [0, 2], [0, 3]].toarray(), x[[0, 1], [0, 2], [0, 3]])
     assert allclose(b[[0, 1, 2], [0, 2, 1], [0, 3, 1]].toarray(), x[[0, 1, 2], [0, 2, 1], [0, 3, 1]])
@@ -73,10 +73,10 @@ def test_getitem_list_array(sc):
     cols = [[0, 2], [0, 2]]
     dept = [[0, 3], [0, 3]]
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     assert allclose(b[rows, cols, dept].toarray(), x[rows, cols, dept])
 
-    b = array(x, sc, axes=(0,1))
+    b = array(x, sc, axis=(0, 1))
     assert allclose(b[rows, cols, dept].toarray(), x[rows, cols, dept])
 
 def test_squeeze(sc):
@@ -84,7 +84,7 @@ def test_squeeze(sc):
     from numpy import ones as npones
 
     x = npones((1, 2, 1, 4))
-    b = ones((1, 2, 1, 4), sc, axes=(0,))
+    b = ones((1, 2, 1, 4), sc, axis=0)
     assert allclose(b.squeeze().toarray(), x.squeeze())
     assert allclose(b.squeeze((0, 2)).toarray(), x.squeeze((0, 2)))
     assert allclose(b.squeeze(0).toarray(), x.squeeze(0))
@@ -94,7 +94,7 @@ def test_squeeze(sc):
     assert b.squeeze(2).split == 1
 
     x = npones((1, 2, 1, 4))
-    b = ones((1, 2, 1, 4), sc, axes=(0, 1))
+    b = ones((1, 2, 1, 4), sc, axis=(0, 1))
     assert allclose(b.squeeze().toarray(), x.squeeze())
     assert allclose(b.squeeze((0, 2)).toarray(), x.squeeze((0, 2)))
     assert allclose(b.squeeze(0).toarray(), x.squeeze(0))
@@ -104,5 +104,5 @@ def test_squeeze(sc):
     assert b.squeeze(2).split == 2
 
     x = npones((1, 1, 1, 1))
-    b = ones((1, 1, 1, 1), sc, axes=(0, 1))
+    b = ones((1, 1, 1, 1), sc, axis=(0, 1))
     assert allclose(b.squeeze().toarray(), x.squeeze())

--- a/test/spark/test_spark_shaping.py
+++ b/test/spark/test_spark_shaping.py
@@ -11,7 +11,7 @@ def test_value_shape(sc):
     assert b.values.shape == (3,)
 
     x = arange(2*3*4).reshape((2, 3, 4))
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     assert b.values.shape == (3, 4)
 
 def test_key_shape(sc):
@@ -21,27 +21,27 @@ def test_key_shape(sc):
     assert b.keys.shape == (2,)
 
     x = arange(2*3*4).reshape((2, 3, 4))
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     assert b.keys.shape == (2, 3)
 
 def test_reshape_keys(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     c = b.keys.reshape((3, 2))
     assert c.keys.shape == (3, 2)
     assert allclose(c.toarray(), x.reshape((3, 2, 4)))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     c = b.keys.reshape((2, 1))
     assert allclose(c.toarray(), x.reshape((2, 1, 3, 4)))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=(0,))
     c = b.keys.reshape((2,))
     assert allclose(c.toarray(), x)
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     c = b.keys.reshape((2, 3))
     assert allclose(c.toarray(), x)
 
@@ -49,7 +49,7 @@ def test_reshape_keys_errors(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     with pytest.raises(ValueError):
         b.keys.reshape((2, 3, 4))
 
@@ -57,20 +57,20 @@ def test_reshape_values(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=(0,))
     c = b.values.reshape((4, 3))
     assert c.values.shape == (4, 3)
     assert allclose(c.toarray(), x.reshape((2, 4, 3)))
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     c = b.values.reshape((1, 4))
     assert allclose(c.toarray(), x.reshape((2, 3, 1, 4)))
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     c = b.values.reshape((4,))
     assert allclose(c.toarray(), x)
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     c = b.values.reshape((3, 4))
     assert allclose(c.toarray(), x)
 
@@ -78,7 +78,7 @@ def test_reshape_values_errors(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     with pytest.raises(ValueError):
         b.values.reshape((2, 3, 4))
 
@@ -86,16 +86,16 @@ def test_transpose_keys(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     c = b.keys.transpose((1, 0))
     assert c.keys.shape == (3, 2)
     assert allclose(c.toarray(), x.transpose((1, 0, 2)))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     c = b.keys.transpose((0,))
     assert allclose(c.toarray(), x)
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     c = b.keys.transpose((0, 1))
     assert allclose(c.toarray(), x)
 
@@ -103,7 +103,7 @@ def test_transpose_keys_errors(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     with pytest.raises(ValueError):
         b.keys.transpose((0, 2))
 
@@ -117,16 +117,16 @@ def test_transpose_values(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     c = b.values.transpose((1, 0))
     assert c.values.shape == (4, 3)
     assert allclose(c.toarray(), x.transpose((0, 2, 1)))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     c = b.values.transpose((0, 1))
     assert allclose(c.toarray(), x)
 
-    b = array(x, sc, axes=(0, 1))
+    b = array(x, sc, axis=(0, 1))
     c = b.values.transpose((0,))
     assert allclose(c.toarray(), x.reshape((2, 3, 4)))
 
@@ -134,7 +134,7 @@ def test_traspose_values_errors(sc):
 
     x = arange(2*3*4).reshape((2, 3, 4))
 
-    b = array(x, sc, axes=(0,))
+    b = array(x, sc, axis=0)
     with pytest.raises(ValueError):
         b.values.transpose((0, 2))
 
@@ -148,7 +148,7 @@ def test_traspose_values_errors(sc):
 def test_swap(sc):
 
     a = arange(2**8).reshape(*(8*[2]))
-    b = array(a, sc, axes=(0, 1, 2, 3))
+    b = array(a, sc, axis=(0, 1, 2, 3))
 
     bs = b.swap((1, 2), (0, 3), size=(2, 2))
     at = a.transpose((0, 3, 4, 7, 1, 2, 5, 6))
@@ -187,7 +187,7 @@ def test_transpose(sc):
 
     a = arange(2*3*4*5).reshape((2, 3, 4, 5))
 
-    b = array(a, sc, axes=[0, 1])
+    b = array(a, sc, axis=(0, 1))
     for p in perms:
         assert allclose(b.transpose(p).toarray(), b.toarray().transpose(p))
 
@@ -195,17 +195,17 @@ def test_t(sc):
 
     a = arange(2*3*4*5).reshape((2, 3, 4, 5))
 
-    b = array(a, sc, axes=[0])
+    b = array(a, sc, axis=0)
     assert allclose(b.T.toarray(), b.toarray().T)
 
-    b = array(a, sc, axes=[0, 1])
+    b = array(a, sc, axis=(0, 1))
     assert allclose(b.T.toarray(), b.toarray().T)
 
 def test_swapaxes(sc):
 
     a = arange(2*3*4*5).reshape((2, 3, 4, 5))
 
-    b = array(a, sc, axes=[0, 1])
+    b = array(a, sc, axis=(0, 1))
     assert allclose(b.swapaxes(1, 2).toarray(), b.toarray().swapaxes(1, 2))
     assert allclose(b.swapaxes(0, 1).toarray(), b.toarray().swapaxes(0, 1))
     assert allclose(b.swapaxes(2, 3).toarray(), b.toarray().swapaxes(2, 3))

--- a/test/spark/test_spark_stacking.py
+++ b/test/spark/test_spark_stacking.py
@@ -9,7 +9,7 @@ def _2D_stackable_preamble(sc, num_partitions=2):
 
     dims = (10, 10)
     arr = vstack([[x]*dims[1] for x in arange(dims[0])])
-    barr = array(arr, sc, axes=(0,))
+    barr = array(arr, sc, axis=0)
     barr = BoltArraySpark(barr._rdd.partitionBy(num_partitions),
                           shape=barr.shape, split=barr.split)
     return barr
@@ -20,7 +20,7 @@ def _3D_stackable_preamble(sc, num_partitions=2):
     dims = (10, 10, 10)
     area = dims[0] * dims[1]
     arr = asarray([repeat(x, area).reshape(dims[0], dims[1]) for x in range(dims[2])])
-    barr = array(arr, sc, axes=(0,))
+    barr = array(arr, sc, axis=0)
     barr = BoltArraySpark(barr._rdd.partitionBy(num_partitions),
                           shape=barr.shape, split=barr.split)
     return barr

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,3 +13,4 @@ def test_argpack():
 
     assert argpack(((1, 2),)) == (1, 2)
     assert argpack((1, 2)) == (1, 2)
+    assert argpack(([0, 1],)) == (0, 1)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -13,4 +13,3 @@ def test_argpack():
 
     assert argpack(((1, 2),)) == (1, 2)
     assert argpack((1, 2)) == (1, 2)
-    assert argpack(([0, 1],)) == (0, 1)


### PR DESCRIPTION
Assorted bug fixes as per our discussion earlier today. Added new unit tests to the map/filter/reduce and all the reduce-based functions in `test_spark_functional.py`. Added better argument handling in both `BoltArrayLocal` and `BoltArraySpark`.

Also added the `noswap` keyword argument to all the functional operators in `BoltArraySpark`. When `noswap` is `True`, functional operations can only be applied across the key axes, and a `ValueError` will be thrown if the `axis` kwarg does not match the key axes. 

TODO 1: The reducer functions on `BoltArrayLocal` do not handle scalar return values properly yet. 
TODO 2: Write tests for the test array in `BoltArraySpark.map`