### PR TITLE
Functional refactor

### DIFF
--- a/bolt/local/array.py
+++ b/bolt/local/array.py
@@ -97,6 +97,12 @@ class BoltArrayLocal(ndarray, BoltArray):
         else:
             raise ValueError("other must be local array, got %s" % type(arry))
 
+    def toscalar(self):
+        if self.shape == ():
+            return self.toarray().reshape(1)[0]
+        else:
+            return self
+
     def tospark(self, sc, axis=0):
         from bolt import array
         return array(self.toarray(), sc, axis=axis)

--- a/bolt/spark/statcounter.py
+++ b/bolt/spark/statcounter.py
@@ -106,14 +106,17 @@ class StatCounter(object):
             raise ValueError("'%s' stat not available, must be requested at "
                              "StatCounter instantiation" % attrname)
 
+    @property
     def mean(self):
         self.__isavail('mean')
         return self.mu
 
+    @property
     def sum(self):
         self.__isavail('sum')
         return self.n * self.mu
 
+    @property
     def variance(self):
         self.__isavail('variance')
         if self.n == 0:
@@ -121,6 +124,7 @@ class StatCounter(object):
         else:
             return self.m2 / self.n
 
+    @property
     def stdev(self):
         self.__isavail('stdev')
-        return sqrt(self.variance())
+        return sqrt(self.variance)

--- a/bolt/spark/utils.py
+++ b/bolt/spark/utils.py
@@ -11,21 +11,6 @@ def _get_kv_func(func, shape, key_axes):
     value_res = [func(axis) for axis in range(len(shape)) if axis not in key_axes]
     return key_res, value_res
 
-def func_axes(b, axis, noswap):
-    if axis is None:
-        axis = 0
-    axis = tupleize(axis)
-    if noswap:
-        key_axes = tuple(range(b.split))
-        if axis != key_axes:
-            raise ValueError("axis must match key axes if noswap == True")
-    return sorted(axis)
-
-def reducer_axes(b, axis):
-    if axis is None:
-        axis = range(len(b.shape))
-    return tupleize(axis)
-
 def zip_with_index(rdd):
     """
     Alternate version of Spark's zipWithIndex that eagerly returns count.

--- a/bolt/spark/utils.py
+++ b/bolt/spark/utils.py
@@ -1,5 +1,3 @@
-from bolt.utils import tupleize
-
 def get_kv_shape(shape, key_axes):
     func = lambda axis: shape[axis]
     return _get_kv_func(func, shape, key_axes)
@@ -27,11 +25,6 @@ def reducer_axes(b, axis):
     if axis is None:
         axis = range(len(b.shape))
     return tupleize(axis)
-
-def extract_scalar(b):
-    if b.shape == ():
-        return b.toarray().reshape(1)[0]
-    return b
 
 def zip_with_index(rdd):
     """

--- a/test/spark/test_spark_functional.py
+++ b/test/spark/test_spark_functional.py
@@ -23,13 +23,6 @@ def test_map(sc):
     b = array(x, sc, axis=(0, 1, 2))
     generic.map_suite(x, b)
 
-    # Test that noswap is respected
-    key_axes = tuple(range(len(b.keys.shape)))
-    val_axes = tuple(map(lambda x: x + b.split, range(len(b.values.shape))))
-    with pytest.raises(ValueError):
-        b.map(lambda x: x, axis=val_axes, noswap=True)
-    assert allclose(b.map(lambda x: x, axis=key_axes, noswap=True).toarray(), b.toarray())
-
 def test_reduce(sc):
 
     from numpy import asarray
@@ -51,13 +44,6 @@ def test_reduce(sc):
     b = array(arr, sc, axis=(0, 1, 2))
     generic.reduce_suite(arr, b)
 
-    # Test that noswap is respected
-    key_axes = tuple(range(len(b.keys.shape)))
-    val_axes = tuple(map(lambda x: x + b.split, range(len(b.values.shape))))
-    with pytest.raises(ValueError):
-        b.reduce(add, axis=val_axes, noswap=True)
-    assert b.reduce(add, axis=key_axes, noswap=True) == b.toarray().sum(axis=key_axes)
-
 def test_filter(sc):
 
     x = arange(2*3*4).reshape(2, 3, 4)
@@ -73,14 +59,6 @@ def test_filter(sc):
     # Split the BoltArraySpark after the third axis (scalar values) and rerun the tests
     b = array(x, sc, axis=(0, 1, 2))
     generic.filter_suite(x, b)
-
-    # Test that noswap is respected
-    b = array(x, sc, axis=0)
-    key_axes = tuple(range(len(b.keys.shape)))
-    val_axes = tuple(map(lambda x: x + b.split, range(len(b.values.shape))))
-    with pytest.raises(ValueError):
-        b.filter(lambda x: x, axis=val_axes, noswap=True)
-    assert allclose(b.filter(lambda x: True, axis=key_axes, noswap=True).toarray(), b.toarray())
 
 def test_mean(sc):
     x = arange(2*3*4).reshape(2, 3, 4)


### PR DESCRIPTION
Made a few changes to the functional operators and added documentation.

Main changes were to revert the new `noswap` argument. I decided that the convenience is not worth the inconsistency in signature between local and spark arrays. Instead, we can (in a separate PR) add new functions to the BoltSparkArray that perform `map`, `reduce`, or `filter` automatically along the splitted axes. Not sure what to call them, something like `map_noswap` or `map_records` or something. It'd be a spark-specific function, rather than modifying the core signature.

I also moved the scalar extraction to the `BoltArrayLocal` class, as it's really a class-specific operation rather than a helper function. And I streamlined the stat handling to avoid so many helper functions.

cc @andrewosh in case anything looks problematic, but otherwise will merge in.
