### PR TITLE
Added __array_wrap__ method to BoltArrayLocal

### DIFF
--- a/bolt/local/array.py
+++ b/bolt/local/array.py
@@ -17,6 +17,12 @@ class BoltArrayLocal(ndarray, BoltArray):
             return
         self._mode = getattr(obj, 'mode', None)
 
+    def __array_wrap__(self, obj):
+        if obj.shape == ():
+            return obj[()]
+        else:
+            return ndarray.__array_wrap__(self, obj)
+
     @property
     def _constructor(self):
         return BoltArrayLocal

--- a/test/local/test_local_functional.py
+++ b/test/local/test_local_functional.py
@@ -1,5 +1,6 @@
 from numpy import arange, repeat
 from bolt import array
+from bolt.utils import allclose
 import generic
 
 
@@ -35,3 +36,17 @@ def test_filter():
 
     # Test all generic filter functionality
     generic.filter_suite(x, b)
+
+def test_ufuncs():
+
+    x = arange(2*3*4*5).reshape(2, 3, 4, 5)
+    b = array(x)
+
+    # test a common ufunc (sum) over different dimensions
+    assert allclose(x.sum(axis=0), b.sum(axis=0).toarray())
+    assert allclose(x.sum(axis=(0, 1)), b.sum(axis=(0, 1)).toarray())
+    assert allclose(x.sum(axis=(0, 1, 2)), b.sum(axis=(0, 1, 2)).toarray())
+    assert x.sum() == b.sum()
+
+
+


### PR DESCRIPTION
If a `ufunc` is called on a `BoltArrayLocal`, it should never return an array with shape `()` (a single element). Standard `ndarray`s extract the scalar out of these arrays and return it instead. The `BoltArrayLocal.__array_wrap__` gives our local arrays the ability to extract out scalar values from ufunc results.  