### PR TITLE
Fixed a bug in BoltArraySpark.filter

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -169,7 +169,8 @@ class BoltArraySpark(BoltArray):
             count = zipped.count()
         reindexed = zipped.map(lambda kv: (kv[1], kv[0]))
 
-        remaining = [swapped.shape[dim] for dim in range(len(swapped.shape)) if dim not in axis]
+        # since we can only filter over one axis, the remaining shape is always the following
+        remaining = list(swapped.shape[1:])
         if count != 0:
             shape = tuple([count] + remaining)
         else:

--- a/test/generic.py
+++ b/test/generic.py
@@ -95,17 +95,17 @@ def filter_suite(arr, b):
     import random
     random.seed(42)
 
-    # Filter all values over the first axis
+    # filter all values over the first axis
     filtered = b.filter(lambda x: False)
     res = filtered.toarray()
     assert res.shape == (0,)
 
-    # Filter no values over the first axis
+    # filter no values over the first axis
     filtered = b.filter(lambda x: True)
     res = filtered.toarray()
     assert res.shape == b.shape
 
-    # Filter out half of the values over the first axis
+    # filter out half of the values over the first axis
     def filter_half(x):
         random.seed(x.tostring())
         return random.random()
@@ -114,3 +114,17 @@ def filter_suite(arr, b):
     res = filtered.toarray()
     assert res.shape[1:] == b.shape[1:]
     assert res.shape[0] <= b.shape[0]
+
+    # filter out half of the values over the second axis
+    filtered = b.filter(lambda x: filter_half(x) < 0.5, axis=1)
+    res = filtered.toarray()
+    assert res.shape[0] <= b.shape[1]
+    assert res.shape[1] == b.shape[0]
+    assert res.shape[2] == b.shape[2]
+
+    # filter out half of the values over the third axis
+    filtered = b.filter(lambda x: filter_half(x) < 0.5, axis=2)
+    res = filtered.toarray()
+    assert res.shape[0] <= b.shape[2]
+    assert res.shape[1] == b.shape[0]
+    assert res.shape[2] == b.shape[1]


### PR DESCRIPTION
`filter` would previously try to compute the shape of the result by indexing into `swapped.shape` and searching for those dimensions not specified in `axis`. This is unnecessary considering `filter` is currently only implemented for single axes, and so it suffices to use the simpler solution of using the shape of all but the first axis of `swapped`. 