### PR TITLE
Smart unstack

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -60,8 +60,8 @@ class BoltArraySpark(BoltArray):
         -------
         StackedArray
         """
-        stk = StackedArray(self._rdd, shape=self.shape, split=self.split, size=size)
-        return stk._stack()
+        stk = StackedArray(self._rdd, shape=self.shape, split=self.split)
+        return stk.stack(size)
 
     def _align(self, axis):
         """

--- a/bolt/spark/stack.py
+++ b/bolt/spark/stack.py
@@ -39,7 +39,7 @@ class StackedArray(object):
     def _constructor(self):
         return StackedArray
 
-    def _stack(self):
+    def stack(self, size):
         """
         Make an intermediate RDD where all records are combined into a
         list of keys and larger ndarray along a new 0th dimension.

--- a/test/spark/test_spark_stacking.py
+++ b/test/spark/test_spark_stacking.py
@@ -1,11 +1,11 @@
-from numpy import arange, repeat
-from bolt import array
+import pytest
+from numpy import arange, repeat, asarray, vstack, tile
+from bolt import array, ones
 from bolt.utils import allclose
 from bolt.spark.array import BoltArraySpark
 
 
 def _2D_stackable_preamble(sc, num_partitions=2):
-    from numpy import vstack
 
     dims = (10, 10)
     arr = vstack([[x]*dims[1] for x in arange(dims[0])])
@@ -15,7 +15,6 @@ def _2D_stackable_preamble(sc, num_partitions=2):
     return barr
 
 def _3D_stackable_preamble(sc, num_partitions=2):
-    from numpy import asarray
 
     dims = (10, 10, 10)
     area = dims[0] * dims[1]
@@ -87,6 +86,53 @@ def test_stacked_map(sc):
         assert normal_map.shape == unstacked.shape
         assert normal_map.split == unstacked.split
         assert allclose(normal_map.toarray(), unstacked.toarray())
+
+def test_stacked_shape_inference(sc):
+
+    from numpy import ones as npones
+
+    a = ones((100, 2), sc)
+    a._rdd = a._rdd.partitionBy(2)
+    s = a.stack(5)
+    n = s.nrecords
+
+    # operations that preserve keys
+    assert s.map(lambda x: x * 2).unstack().shape == (100, 2)
+    assert s.map(lambda x: x.sum(axis=1)).unstack().shape == (100,)
+    assert s.map(lambda x: tile(x, (1, 2))).unstack().shape == (100, 4)
+
+    # operations that create new keys
+    assert s.map(lambda x: npones((2, 2))).unstack().shape == (n, 2, 2)
+    assert s.map(lambda x: x.sum(axis=0)).unstack().shape == (n, 2)
+    assert s.map(lambda x: asarray([2])).unstack().toarray().shape == (n, 1)
+    assert s.map(lambda x: asarray(2)).unstack().toarray().shape == (n,)
+
+    # composing functions works
+    assert s.map(lambda x: x * 2).map(lambda x: x * 2).unstack().shape == (100, 2)
+    assert s.map(lambda x: x * 2).map(lambda x: npones((2, 2))).unstack().shape == (n, 2, 2)
+    assert s.map(lambda x: npones((2, 2))).map(lambda x: x * 2).unstack().shape == (n, 2, 2)
+
+    # check the result
+    assert allclose(s.map(lambda x: x.sum(axis=1)).unstack().toarray(), npones(100) * 2)
+    assert allclose(s.map(lambda x: tile(x, (1, 2))).unstack().toarray(), npones((100, 4)))
+
+    with pytest.raises(ValueError):
+        s.map(lambda x: 2)
+
+    with pytest.raises(ValueError):
+        s.map(lambda x: None)
+
+    with pytest.raises(RuntimeError):
+        s.map(lambda x: 1/0)
+
+def test_stacked_nrecords(sc):
+
+    a = ones((100, 2), sc)
+    a._rdd = a._rdd.partitionBy(2)
+
+    assert a.stack(1).nrecords == 100
+    assert a.stack(5).nrecords == 20
+    assert a.stack(10).nrecords == 10
 
 def test_stacked_conversion(sc):
 

--- a/test/spark/test_spark_stacking.py
+++ b/test/spark/test_spark_stacking.py
@@ -94,7 +94,7 @@ def test_stacked_shape_inference(sc):
     a = ones((100, 2), sc)
     a._rdd = a._rdd.partitionBy(2)
     s = a.stack(5)
-    n = s.nrecords
+    n = s.tordd().count()
 
     # operations that preserve keys
     assert s.map(lambda x: x * 2).unstack().shape == (100, 2)
@@ -124,15 +124,6 @@ def test_stacked_shape_inference(sc):
 
     with pytest.raises(RuntimeError):
         s.map(lambda x: 1/0)
-
-def test_stacked_nrecords(sc):
-
-    a = ones((100, 2), sc)
-    a._rdd = a._rdd.partitionBy(2)
-
-    assert a.stack(1).nrecords == 100
-    assert a.stack(5).nrecords == 20
-    assert a.stack(10).nrecords == 10
 
 def test_stacked_conversion(sc):
 


### PR DESCRIPTION
This PR improves handling of stacked arrays by automatically inferring changes to the shape of the values and handling unstacking accordingly.

Given that we only support `map` operations on stacked arrays, I found a way to use multiple test function evaluation to infer what to do in what I think is an exhaustive set of cases. The key idea is to figure out whether an operation on stacked arrays acts homogeneously, by testing on just two test arrays of different shapes, and propagate handling of either case.

Also added better error handling of test evaluation, which we should port to the main Spark bolt array.

See the unit tests for all the cases that are covered correctly. 

The only problem is that a map that homogenizes values is not lazy; the moment you call such a `map`, we recompute new keys, which requires evaluation. Subsequent `map` operations are still lazy, and unstacking itself is lazy. But this is somewhat annoying.

It'd be really cool to avoid this, and I wonder if it's possible given that before stacking we know (a) the number of partitions (b) the number of records (c) the number of records that will get aggregated. 

The other option is to move the rekeying to the call to `unstack`. That's how I had it originally, and it feels more Spark-like for the evaluation to happen there than during a simple `map`, but in order to get shape correct for the `map` we need to at least know the total number of records, which requires an evaluation anyway. So I just moved the rekeying to happen during the `map` to do it all at once.