### PR TITLE
Refactor chunking

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -509,7 +509,7 @@ class BoltArraySpark(BoltArray):
             tosqueeze = tuple([i for i in index if isinstance(i, int)])
             return result.squeeze(tosqueeze)
 
-    def swap(self, key_axes, value_axes, size=150):
+    def swap(self, kaxes, vaxes, size=150):
         """
         Swap axes from keys to values.
 
@@ -533,14 +533,14 @@ class BoltArraySpark(BoltArray):
         -------
         BoltArraySpark
         """
-        key_axes, value_axes = tupleize(key_axes), tupleize(value_axes)
-        key_axes, value_axes = asarray(key_axes, 'int'), asarray(value_axes, 'int')
+        kaxes = asarray(tupleize(kaxes), 'int')
+        vaxes = asarray(tupleize(vaxes), 'int')
 
-        if len(key_axes) == self.keys.ndim and len(value_axes) == 0:
+        if len(kaxes) == self.keys.ndim and len(vaxes) == 0:
             raise ValueError('Cannot perform a swap that would '
                              'end up with all data on a single key')
 
-        if len(key_axes) == 0 and len(value_axes) == 0:
+        if len(kaxes) == 0 and len(vaxes) == 0:
             return self
 
         if self.values.ndim == 0:
@@ -554,8 +554,8 @@ class BoltArraySpark(BoltArray):
 
         s = ChunkedArray(rdd, shape=shape, split=self.split, dtype=self.dtype)
 
-        s = s.chunk(size, key_axes, value_axes)
-        out = s.unchunk(size, key_axes, value_axes)
+        s = s.chunk(size, kaxes, vaxes)
+        out = s.unchunk(size, kaxes, vaxes)
 
         if self.values.ndim == 0:
             out._rdd = out._rdd.mapValues(lambda v: v.squeeze())

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -509,7 +509,7 @@ class BoltArraySpark(BoltArray):
             tosqueeze = tuple([i for i in index if isinstance(i, int)])
             return result.squeeze(tosqueeze)
 
-    def chunk(self, size=150, axis=None):
+    def chunk(self, size="150", axis=None):
         """
         Chunks records of a distributed array.
 
@@ -520,8 +520,8 @@ class BoltArraySpark(BoltArray):
 
         Parameters
         ----------
-        size : tuple or int, optional, default = 150
-            A size in megabytes, or a tuple with the number
+        size : tuple or string, optional, default = "150"
+            A string giving the size in megabytes, or a tuple with the number
             of chunks along each dimension.
 
         Returns
@@ -542,6 +542,8 @@ class BoltArraySpark(BoltArray):
         on the Spark bolt array. It exchanges an arbitrary set of axes
         between the keys and the valeus. If either is None, will only
         move axes in one direction (from keys to values, or values to keys).
+        Keys moved to values will be placed immediately after the split; 
+        values moved to keys will be placed immediately before the split.
 
         Parameters
         ----------
@@ -551,8 +553,8 @@ class BoltArraySpark(BoltArray):
         vaxes : tuple
             Axes from values to move to keys
 
-        size : tuple or int, optional, default = 150
-            Can either provide a size in megabytes,
+        size : tuple or int, optional, default = "150"
+            Can either provide a string giving the size in megabytes,
             or a tuple with the number of chunks along each
             value dimension being moved
 

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -510,12 +510,30 @@ class BoltArraySpark(BoltArray):
             return result.squeeze(tosqueeze)
 
     def chunk(self, size=150):
+        """
+        Chunks records of a distributed array.
+
+        Chunking breaks arrays into subarrays, using an specified
+        number of chunks along each dimension. Can altenratively
+        specify an average chunk size (in megabytes) and the number of
+        chunks will be computed automatically.
+
+        Parameters
+        ----------
+        size : tuple or int, optional, default = 150
+            A size in megabytes, or a tuple with the number
+            of chunks along each dimension.
+
+        Returns
+        -------
+        ChunkedArray
+        """
 
         from bolt.spark.swap import ChunkedArray
 
         chnk = ChunkedArray(rdd=self._rdd, shape=self._shape, split=self._split, dtype=self._dtype)
-        return chnk.chunked(size)
-
+        p = chnk.getplan(size)
+        return chnk.chunk(p)
 
     def swap(self, kaxes, vaxes, size=150):
         """
@@ -528,14 +546,16 @@ class BoltArraySpark(BoltArray):
 
         Parameters
         ----------
-        key_axes : tuple
+        kaxes : tuple
             Axes from keys to move to values
 
-        value_axes ; tuple
+        vaxes : tuple
             Axes from values to move to keys
 
-        size : int
-            Size of chunks to use, in megabytes
+        size : tuple or int, optional, default = 150
+            Can either provide a size in megabytes,
+            or a tuple with the number of chunks along each
+            value dimension being moved
 
         Returns
         -------

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -514,20 +514,27 @@ class BoltArraySpark(BoltArray):
         Chunks records of a distributed array.
 
         Chunking breaks arrays into subarrays, using an specified
-        number of chunks along each dimension. Can altenratively
+        number of chunks along each dimension. Can alternatively
         specify an average chunk size (in megabytes) and the number of
         chunks will be computed automatically.
 
         Parameters
         ----------
-        size : tuple or string, optional, default = "150"
+        size : tuple, int, or str, optional, default = "150"
             A string giving the size in megabytes, or a tuple with the number
             of chunks along each dimension.
+
+        axis : int or tuple, optional, default = None
+            One or more axis to chunk array along, if None
+            will use all axes,
 
         Returns
         -------
         ChunkedArray
         """
+        if type(size) is not str:
+            size = tupleize((size))
+        axis = tupleize((axis))
 
         from bolt.spark.swap import ChunkedArray
 

--- a/bolt/spark/stack.py
+++ b/bolt/spark/stack.py
@@ -4,7 +4,7 @@ from bolt.spark.utils import zip_with_index
 class StackedArray(object):
     """
     Wraps a BoltArraySpark and provides an interface for performing
-    stacked operations (operations on whole subarrays). Many methods
+    stacked operations (operations on aggregated subarrays). Many methods
     will be restricted or forbidden until the Stacked object is
     unstacked. Currently, only map() is implemented. The rationale
     is that many operations will work faster when vectorized over a

--- a/bolt/spark/swap.py
+++ b/bolt/spark/swap.py
@@ -109,7 +109,7 @@ class ChunkedArray(object):
 
         full_shape = concatenate((nchunks, plan))
         n = len(vshape)
-        perm = concatenate(zip(arange(n), range(n, 2*n)))
+        perm = concatenate(list(zip(range(n), range(n, 2*n))))
 
         if sum(mod(vshape, plan)) == 0:
             def _unchunk(v):
@@ -308,7 +308,7 @@ class ChunkedArray(object):
         """
         slices = []
         for size, d in zip(plan, shape):
-            nchunks = d/size #integer division
+            nchunks = int(floor(d/size))
             remainder = d % size 
             start = 0
             dimslices = []

--- a/bolt/spark/swap.py
+++ b/bolt/spark/swap.py
@@ -217,7 +217,7 @@ class ChunkedArray(object):
              If int/tuple, an explicit specification of the number chunks in 
              each moving value dimension.
 
-        axis : tuple, optional, default=None
+        axes : tuple, optional, default=None
               One or more axes to estimate chunks for, if provided any
               other axes will use one chunk.
         """
@@ -277,7 +277,7 @@ class ChunkedArray(object):
 
         Parameters
         ----------
-        chunk_sizes: tuple or array-like
+        plan: tuple or array-like
             Size of chunks (in number of elements) along each dimensions.
             Length must be equal to the number of dimensions.
 
@@ -299,11 +299,11 @@ class ChunkedArray(object):
 
         Parameters
         ----------
-        chunk_sizes: tuple or array-like
+        plan: tuple or array-like
             Size of chunks (in number of elements) along each dimensions.
             Length must be equal to the number of dimensions.
 
-        dims : tuple
+        shape: tuple
              Dimensions of axes to be chunked.
         """
         slices = []

--- a/bolt/spark/swap.py
+++ b/bolt/spark/swap.py
@@ -64,14 +64,6 @@ class ChunkedArray(object):
                 object.__setattr__(self, name, other_attr)
         return self
 
-    def getshape(self, kaxes, vaxes):
-        """
-        Get resulting shape after swapping. This returns an array[int] of:
-        [unswapped keys, swapped values, swapped keys, unswapped values]
-        """
-        return tuple(r_[self.kshape[~self.kmask(kaxes)], self.vshape[self.vmask(vaxes)],
-                     self.kshape[self.kmask(kaxes)], self.vshape[~self.vmask(vaxes)]].astype('int'))
-
     def chunk(self, size, kaxes, vaxes):
         """
         Convert values of a BoltSparkArray into chunks. This transforms
@@ -169,8 +161,9 @@ class ChunkedArray(object):
                 yield (tuple(asarray(r_[stationary_key, key_offsets + b], dtype='int')), values[tuple(s)])
 
         rdd = self._rdd.groupByKey().flatMap(_extract)
-        shape = self.getshape(kaxes, vaxes)
         split = self._split - len(kaxes) + len(vaxes)
+        shape = tuple(r_[kshape[~kmask], vshape[vmask],
+                         kshape[kmask], vshape[~vmask]].astype('int'))
 
         return BoltArraySpark(rdd, shape=shape, split=split)
 

--- a/bolt/utils.py
+++ b/bolt/utils.py
@@ -11,6 +11,8 @@ def tupleize(arg):
     arg : tuple, list, ndarray, or singleton
         Item to coerce
     """
+    if arg is None:
+        return None
     if not isinstance(arg, (tuple, list, ndarray, Iterable)):
         return tuple((arg,))
     elif isinstance(arg, (list, ndarray)):
@@ -158,7 +160,7 @@ def istransposeable(new, old):
     
     if any(n < 0 for n in new) or max(new) > len(old) - 1:
         raise ValueError("Invalid axes")
-    
+
 def isreshapeable(new, old):
     """
     Check to see if a proposed tuple of axes is a valid reshaping of
@@ -178,14 +180,18 @@ def isreshapeable(new, old):
     if not prod(new) == prod(old):
         raise ValueError("Total size of new keys must remain unchanged")
 
-def allstack(cls, vals, depth=0):
+def allstack(vals, depth=0):
     """
     Try to stack a (potentially nested) list of ndarrays into a
     single ndarray. The dimensions of the individual ndarrays
     must be consistent with this operation.
+
+    Parameters
+    ----------
+    ...
     """
     if type(vals[0]) is ndarray:
         return concatenate(vals, axis=depth)
     else:
-        return concatenate([cls.allstack(x, depth+1) for x in vals], axis=depth)
+        return concatenate([allstack(x, depth+1) for x in vals], axis=depth)
 

--- a/bolt/utils.py
+++ b/bolt/utils.py
@@ -180,18 +180,21 @@ def isreshapeable(new, old):
     if not prod(new) == prod(old):
         raise ValueError("Total size of new keys must remain unchanged")
 
-def allstack(vals, depth=0):
+def allstack(vals, _depth=0):
     """
-    Try to stack a (potentially nested) list of ndarrays into a
-    single ndarray. The dimensions of the individual ndarrays
-    must be consistent with this operation.
+    If an ndarray has been split into multiple chunks by splitting it along
+    each axis at a number of locations, this function rebuilds the
+    original array from chunks.
 
     Parameters
     ----------
+    vals: nested lists of ndarrays
+        each level of nesting of the lists representing a dimension of
+        the original array.
     ...
     """
     if type(vals[0]) is ndarray:
-        return concatenate(vals, axis=depth)
+        return concatenate(vals, axis=_depth)
     else:
-        return concatenate([allstack(x, depth+1) for x in vals], axis=depth)
+        return concatenate([allstack(x, _depth+1) for x in vals], axis=_depth)
 

--- a/bolt/utils.py
+++ b/bolt/utils.py
@@ -1,4 +1,4 @@
-from numpy import ndarray, asarray, prod
+from numpy import ndarray, asarray, prod, concatenate
 from numpy import any as npany
 from collections import Iterable
 
@@ -177,3 +177,15 @@ def isreshapeable(new, old):
 
     if not prod(new) == prod(old):
         raise ValueError("Total size of new keys must remain unchanged")
+
+def allstack(cls, vals, depth=0):
+    """
+    Try to stack a (potentially nested) list of ndarrays into a
+    single ndarray. The dimensions of the individual ndarrays
+    must be consistent with this operation.
+    """
+    if type(vals[0]) is ndarray:
+        return concatenate(vals, axis=depth)
+    else:
+        return concatenate([cls.allstack(x, depth+1) for x in vals], axis=depth)
+

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -25,5 +25,13 @@ def test_unchunk(sc):
     x = arange(4*6).reshape(1, 4, 6)
     b = array(x, sc)
 
-    allclose(b.chunk((2,3)).unchunk().toarray(), b.toarray())
-    allclose(b.chunk((3,4)).unchunk().toarray(), b.toarray())
+    allclose(b.chunk((2, 3)).unchunk().toarray(), b.toarray())
+    allclose(b.chunk((3, 4)).unchunk().toarray(), b.toarray())
+
+    x = arange(4*5*10).reshape(1, 4, 5, 10)
+    b = array(x, sc)
+
+    allclose(b.chunk((4, 5, 10)).unchunk().toarray(), b.toarray())
+    allclose(b.chunk((1, 1, 1)).unchunk().toarray(), b.toarray())
+    allclose(b.chunk((3, 3, 3)).unchunk().toarray(), b.toarray())
+    allclose(b.chunk((3, 3, 3)).unchunk().toarray(), b.toarray())

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -1,0 +1,29 @@
+import pytest
+from numpy import arange, split
+from bolt import array
+from bolt.utils import allclose
+
+def test_chunk(sc):
+    
+    x = arange(4*6).reshape(1, 4, 6)
+    b = array(x, sc)
+    
+    k1, v1 = zip(*b.chunk((2,3))._rdd.sortByKey().collect())
+    k2 = tuple(zip(((0,), (0,), (0,), (0,)), ((0, 0), (0, 1), (1, 0), (1, 1))))
+    v2 = [s for m in split(x[0], (2,), axis=0) for s in split(m, (3,), axis=1)]
+    assert k1 == k2
+    assert all([allclose(m1, m2) for (m1, m2) in zip(v1, v2)])
+
+    k1, v1 = zip(*b.chunk((3,4))._rdd.sortByKey().collect())
+    k2 = tuple(zip(((0,), (0,), (0,), (0,)), ((0, 0), (0, 1), (1, 0), (1, 1))))
+    v2 = [s for m in split(x[0], (3,), axis=0) for s in split(m, (4,), axis=1)]
+    assert k1 == k2
+    assert all([allclose(m1, m2) for (m1, m2) in zip(v1, v2)])
+
+def test_unchunk(sc):
+
+    x = arange(4*6).reshape(1, 4, 6)
+    b = array(x, sc)
+
+    allclose(b.chunk((2,3)).unchunk().toarray(), b.toarray())
+    allclose(b.chunk((3,4)).unchunk().toarray(), b.toarray())

--- a/test/spark/test_spark_shaping.py
+++ b/test/spark/test_spark_shaping.py
@@ -154,7 +154,7 @@ def test_swap(sc):
     at = a.transpose((0, 3, 4, 7, 1, 2, 5, 6))
     assert allclose(at, bs.toarray())
 
-    bs = b.swap((1, 2), (0, 3), size=50)
+    bs = b.swap((1, 2), (0, 3), size="50")
     at = a.transpose((0, 3, 4, 7, 1, 2, 5, 6))
     assert allclose(at, bs.toarray())
 


### PR DESCRIPTION
Addresses #56 

The `BoltArraySpark` allows the user to divide an array into distributed pieces, but these divisions must occur in at the level of entire axes. This PR introduces a new `ChunkedArray` that allows for finer subdivision, this time within axes. The plan is for this object to expose only a limited number of methods. Right now this includes:

- `chunk`: for performing the subdivision
- `unchunk`: for putting the array back together into a proper `BoltArraySpark`
- `move`: a mostly internal method that `BoltArraySpark.swap` uses to change key-axes to value-axes.

The plan is to also expose `map`, which will probably be the main draw of this data structure. We imagine a standard work-flow that will look like `BoltArraySpark.chunk(size).map(f).unchunk()`. This is useful for cases where the size of the distributed dimension(s) is so small that one cannot leverage the entire power of the cluster. For example, imagine a moderate number of very large images. If the user wants to do image processing, then the images must be value-dimensions. However, if there are fewer images than there are cores in the cluster, then simply performing a `map` over the images will not use all of the cores. Fortunately, if the image processing acts independently on sub-images, then one can first `chunk` then `map` and finally `unchunk`.