### PR TITLE
ChunkedArray refactor

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -631,7 +631,7 @@ class BoltArraySpark(BoltArray):
         c = ChunkedArray(self._rdd, shape=self._shape, split=self._split, dtype=self._dtype)
 
         chunks = c._chunk(size, axis=vaxes)
-        swapped = chunks.keystovalues(kaxes).valuestokeys([v+len(kaxes) for v in vaxes])
+        swapped = chunks.keys_to_values(kaxes).values_to_keys([v+len(kaxes) for v in vaxes])
         barray = swapped.unchunk()
 
         return barray

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -229,7 +229,7 @@ class ChunkedArray(object):
         # update properties
         newplan = self.plan[~vmask]
         newsplit = self._split + len(axes)
-        newshape = tuple(r_[self.kshape, self.vshape[vmask], self.vshape[~vmask]])
+        newshape = tuple(r_[self.kshape, self.vshape[vmask], self.vshape[~vmask]].astype('int'))
 
         result = self._constructor(None, shape=newshape, split=newsplit, dtype=self.dtype, plan=newplan)
 

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -173,11 +173,10 @@ class ChunkedArray(object):
         -------
         ChunkedArray
         """
+        kmask = self.kmask(axes)
 
         if size is None:
-            size = tuple(len(axes)*[1])
-
-        kmask = self.kmask(axes)
+            size = self.kshape[kmask]
 
         # update properties
         newplan = r_[size, self.plan]
@@ -260,10 +259,12 @@ class ChunkedArray(object):
 
         result._rdd = self._rdd.flatMap(_extract)
 
-        if len(self.vshape == 0):
+        print result.shape
+        print result.vshape
+        if len(result.vshape) == 0:
             result._rdd = result._rdd.mapValues(lambda v: array(v, ndmin=1))
             result._shape = result._shape + (1,)
-            result._plan = result._plan + (1,)
+            result._plan = (1,)
 
         return result
 

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -156,7 +156,7 @@ class ChunkedArray(object):
 
         return BoltArraySpark(rdd, shape=newshape, split=self._split)
 
-    def keystovalues(self, axes, size=None):
+    def keys_to_values(self, axes, size=None):
         """
         Move indices in the keys into the values.
 
@@ -222,7 +222,7 @@ class ChunkedArray(object):
 
         return result
 
-    def valuestokeys(self, axes):
+    def values_to_keys(self, axes):
 
         vmask = self.vmask(axes)
 

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -478,4 +478,10 @@ class ChunkedArray(object):
         return s
 
     def __repr__(self):
-        return str(self)
+        string = str(self)
+        if array_equal(self.vshape, [1]):
+            newlines = [i for (i, char) in enumerate(string) if char=='\n']
+            string = string[:newlines[-2]+1]
+            string += "shape: %s\n" % str(self.shape[:-1])
+        return string
+

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -259,8 +259,6 @@ class ChunkedArray(object):
 
         result._rdd = self._rdd.flatMap(_extract)
 
-        print result.shape
-        print result.vshape
         if len(result.vshape) == 0:
             result._rdd = result._rdd.mapValues(lambda v: array(v, ndmin=1))
             result._shape = result._shape + (1,)

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -36,6 +36,30 @@ def test_unchunk(sc):
     assert allclose(b.chunk((3, 3, 3)).unchunk().toarray(), b.toarray())
     assert allclose(b.chunk((3, 3, 3)).unchunk().toarray(), b.toarray())
 
+def test_keystovalues(sc):
+
+    x = arange(4*7*9*6).reshape(4, 7, 9, 6)
+    b = array(x, sc, (0, 1))
+    c = b.chunk((4, 2))
+
+    assert allclose(x, c.keystovalues((0,)).unchunk().toarray().transpose(1, 0, 2, 3))
+    assert allclose(x, c.keystovalues((1,)).unchunk().toarray())
+    assert allclose(x, c.keystovalues((1,), size=(3,)).unchunk().toarray())
+    assert allclose(x, c.keystovalues((0, 1)).unchunk().toarray())
+    assert allclose(x, c.keystovalues((0, 1), size=(2, 3)).unchunk().toarray())
+    assert allclose(x, c.keystovalues(()).unchunk().toarray())
+
+def test_valuestokeys(sc):
+
+    x = arange(4*7*9*6).reshape(4, 7, 9, 6)
+    b = array(x, sc, (0, 1))
+    c = b.chunk((4, 2))
+
+    assert allclose(x, c.valuestokeys((0,)).unchunk().toarray())
+    assert allclose(x, c.valuestokeys((1,)).unchunk().toarray().transpose(0, 1, 3, 2))
+    assert allclose(x, c.valuestokeys((0, 1)).unchunk().toarray())
+    assert allclose(x, c.valuestokeys(()).unchunk().toarray())
+
 def test_map(sc):
 
     x = arange(4*6).reshape(1, 4, 6)

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -36,6 +36,11 @@ def test_unchunk(sc):
     assert allclose(b.chunk((3, 3, 3)).unchunk().toarray(), b.toarray())
     assert allclose(b.chunk((3, 3, 3)).unchunk().toarray(), b.toarray())
 
+    x = arange(4*6).reshape(4, 6)
+    b = array(x, sc, (0, 1))
+
+    assert allclose(b.chunk(()).unchunk().toarray(), b.toarray())
+
 def test_keystovalues(sc):
 
     x = arange(4*7*9*6).reshape(4, 7, 9, 6)
@@ -48,6 +53,12 @@ def test_keystovalues(sc):
     assert allclose(x, c.keystovalues((0, 1)).unchunk().toarray())
     assert allclose(x, c.keystovalues((0, 1), size=(2, 3)).unchunk().toarray())
     assert allclose(x, c.keystovalues(()).unchunk().toarray())
+
+    b = array(x, sc, range(4))
+    c = b.chunk(())
+
+    assert allclose(x, c.keystovalues((3,)).unchunk().toarray())
+    assert allclose(x, c.keystovalues((0, 1)).unchunk().transpose(2, 3, 0, 1))
 
 def test_valuestokeys(sc):
 

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -41,35 +41,35 @@ def test_unchunk(sc):
 
     assert allclose(b.chunk(()).unchunk().toarray(), b.toarray())
 
-def test_keystovalues(sc):
+def test_keys_to_values(sc):
 
     x = arange(4*7*9*6).reshape(4, 7, 9, 6)
     b = array(x, sc, (0, 1))
     c = b.chunk((4, 2))
 
-    assert allclose(x, c.keystovalues((0,)).unchunk().toarray().transpose(1, 0, 2, 3))
-    assert allclose(x, c.keystovalues((1,)).unchunk().toarray())
-    assert allclose(x, c.keystovalues((1,), size=(3,)).unchunk().toarray())
-    assert allclose(x, c.keystovalues((0, 1)).unchunk().toarray())
-    assert allclose(x, c.keystovalues((0, 1), size=(2, 3)).unchunk().toarray())
-    assert allclose(x, c.keystovalues(()).unchunk().toarray())
+    assert allclose(x, c.keys_to_values((0,)).unchunk().toarray().transpose(1, 0, 2, 3))
+    assert allclose(x, c.keys_to_values((1,)).unchunk().toarray())
+    assert allclose(x, c.keys_to_values((1,), size=(3,)).unchunk().toarray())
+    assert allclose(x, c.keys_to_values((0, 1)).unchunk().toarray())
+    assert allclose(x, c.keys_to_values((0, 1), size=(2, 3)).unchunk().toarray())
+    assert allclose(x, c.keys_to_values(()).unchunk().toarray())
 
     b = array(x, sc, range(4))
     c = b.chunk(())
 
-    assert allclose(x, c.keystovalues((3,)).unchunk().toarray())
-    assert allclose(x, c.keystovalues((0, 1)).unchunk().transpose(2, 3, 0, 1))
+    assert allclose(x, c.keys_to_values((3,)).unchunk().toarray())
+    assert allclose(x, c.keys_to_values((0, 1)).unchunk().transpose(2, 3, 0, 1))
 
-def test_valuestokeys(sc):
+def test_values_to_keys(sc):
 
     x = arange(4*7*9*6).reshape(4, 7, 9, 6)
     b = array(x, sc, (0, 1))
     c = b.chunk((4, 2))
 
-    assert allclose(x, c.valuestokeys((0,)).unchunk().toarray())
-    assert allclose(x, c.valuestokeys((1,)).unchunk().toarray().transpose(0, 1, 3, 2))
-    assert allclose(x, c.valuestokeys((0, 1)).unchunk().toarray())
-    assert allclose(x, c.valuestokeys(()).unchunk().toarray())
+    assert allclose(x, c.values_to_keys((0,)).unchunk().toarray())
+    assert allclose(x, c.values_to_keys((1,)).unchunk().toarray().transpose(0, 1, 3, 2))
+    assert allclose(x, c.values_to_keys((0, 1)).unchunk().toarray())
+    assert allclose(x, c.values_to_keys(()).unchunk().toarray())
 
 def test_map(sc):
 


### PR DESCRIPTION
Refactored `ChunkedArray` to allow it to back Thunder's `Blocks` object.

The key change is that  `ChunkedArray.swap()` has been removed; replacing it are two more general functions: `keystovalues` and `valuestokeys`. `BoltArraySpark.swap()` now involves the following steps:
1. Create a `ChunkedArray` from the `BoltArraySpark` to break the values into chunks with `_chunk`
2. Use `keystovalues` to move some of the keys to the values
3. Use `valuestokeys` to move some of the values to the keys
4. Return put the values back together again with `unchunk`

During the `keystovalues` operation, we can specify if we would like to the new values to be chunked as well. If we choose not to chunk them and stop after step 2, then the resulting `ChunkedArray` is precisely what we want to back Thunder's `Blocks` object. This will be the pattern for both `Images.toSeries` and `Series.toImages`.

Then, depending on how we subsequently call `valuestokeys` we can implement `Blocks.toImages` or `Blocks.toSeries`.