### PR TITLE
Padding

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -576,7 +576,6 @@ class BoltArraySpark(BoltArray):
             If a tuple, specifies padding along each chunked dimension; if a int, same
             padding will be applied to all chunked dimensions.
 
-
         Returns
         -------
         ChunkedArray
@@ -599,7 +598,7 @@ class BoltArraySpark(BoltArray):
         on the Spark bolt array. It exchanges an arbitrary set of axes
         between the keys and the valeus. If either is None, will only
         move axes in one direction (from keys to values, or values to keys).
-        Keys moved to values will be placed immediately after the split; 
+        Keys moved to values will be placed immediately after the split;
         values moved to keys will be placed immediately before the split.
 
         Parameters
@@ -669,7 +668,7 @@ class BoltArraySpark(BoltArray):
         swapping_values = sort(new_keys[new_keys >= split])
         stationary_keys = sort(new_keys[new_keys < split])
         stationary_values = sort(new_values[new_values >= split])
-        
+
         # compute the permutation that the swap causes
         p_swap = r_[stationary_keys, swapping_values, swapping_keys, stationary_values]
 
@@ -683,7 +682,7 @@ class BoltArraySpark(BoltArray):
         arr = self.swap(swapping_keys, swapping_values-split)
         arr = arr.keys.transpose(tuple(p_keys.tolist()))
         arr = arr.values.transpose(tuple(p_values.tolist()))
-        
+
         return arr
 
     @property
@@ -903,5 +902,3 @@ class BoltArraySpark(BoltArray):
         """
         for x in self._rdd.take(10):
             print(x)
-
-

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -552,7 +552,7 @@ class BoltArraySpark(BoltArray):
             tosqueeze = tuple([k for k, i in enumerate(index) if isinstance(i, int)])
             return result.squeeze(tosqueeze)
 
-    def chunk(self, size="150", axis=None):
+    def chunk(self, size="150", axis=None, padding=None):
         """
         Chunks records of a distributed array.
 
@@ -571,6 +571,12 @@ class BoltArraySpark(BoltArray):
             One or more axis to chunk array along, if None
             will use all axes,
 
+        padding: tuple or int, default = None
+            Number of elements per dimension that will overlap with the adjacent chunk.
+            If a tuple, specifies padding along each chunked dimension; if a int, same
+            padding will be applied to all chunked dimensions.
+
+
         Returns
         -------
         ChunkedArray
@@ -578,11 +584,12 @@ class BoltArraySpark(BoltArray):
         if type(size) is not str:
             size = tupleize((size))
         axis = tupleize((axis))
+        padding = tupleize((padding))
 
         from bolt.spark.chunk import ChunkedArray
 
         chnk = ChunkedArray(rdd=self._rdd, shape=self._shape, split=self._split, dtype=self._dtype)
-        return chnk._chunk(size, axis)
+        return chnk._chunk(size, axis, padding)
 
     def swap(self, kaxes, vaxes, size="150"):
         """

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -169,7 +169,7 @@ class ChunkedArray(object):
         # remove padding
         if self.padded:
             removepad = self.removepad
-            rdd = self._rdd.map(lambda (k, v): (k, removepad(k[1], v, nchunks, padding, axes=range(n))))
+            rdd = self._rdd.map(lambda kv: (kv[0], removepad(kv[0][1], kv[1], nchunks, padding, axes=range(n))))
         else:
             rdd = self._rdd
 
@@ -274,7 +274,7 @@ class ChunkedArray(object):
             plan, padding = self.plan, self.padding
             nchunks = self.getnumber(plan, self.vshape)
             removepad = self.removepad
-            rdd = self._rdd.map(lambda (k, v): (k, removepad(k[1], v, nchunks, padding, axes=axes)))
+            rdd = self._rdd.map(lambda kv: (kv[0], removepad(kv[0][1], kv[1], nchunks, padding, axes=axes)))
         else:
             rdd = self._rdd
 

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -57,7 +57,7 @@ class ChunkedArray(object):
     @property
     def padded(self):
         return not all([p == 0 for p in self.padding])
-    
+
     @property
     def kshape(self):
         return asarray(self._shape[:self._split])
@@ -104,10 +104,10 @@ class ChunkedArray(object):
             One or more axes to estimate chunks for, if provided any
             other axes will use one chunk.
 
-        padding : tuple or int, option, default=None
-            Size over overlapping padding between chunks in each dimension.
-            If tuple, specifies padding along each chunked dimension; if int,
-            all dimensions use same padding; if None, no padding
+        padding: tuple or int, default = None
+            Number of elements per dimension that will overlap with the adjacent chunk.
+            If a tuple, specifies padding along each chunked dimension; if a int, same
+            padding will be applied to all chunked dimensions.
         """
         if self.split == len(self.shape) and padding is None:
             self._rdd = self._rdd.map(lambda kv: ((kv[0], ()), array(kv[1], ndmin=1)))
@@ -377,8 +377,8 @@ class ChunkedArray(object):
         Parameters
         ----------
         size : string or tuple
-             If str, the average size (in MB) of the chunks in all value dimensions.  
-             If int/tuple, an explicit specification of the number chunks in 
+             If str, the average size (in MB) of the chunks in all value dimensions.
+             If int/tuple, an explicit specification of the number chunks in
              each moving value dimension.
 
         axes : tuple, optional, default=None
@@ -530,7 +530,7 @@ class ChunkedArray(object):
         slices = []
         for size, pad, d in zip(plan, padding, shape):
             nchunks = int(floor(d/size))
-            remainder = d % size 
+            remainder = d % size
             start = 0
             dimslices = []
             for idx in range(nchunks):
@@ -618,4 +618,3 @@ class ChunkedArray(object):
             string += "chunk size: none\n"
 
         return string
-

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -148,9 +148,11 @@ class ChunkedArray(object):
         n = len(vshape)
         perm = concatenate(list(zip(range(n), range(n, 2*n))))
 
+        removepad = self.removepad
+
         def unpad(v):
             inds, data = zip(*v.data)
-            return inds, [self.removepad(idx, val, plan, padding) for (idx, val) in zip(inds, data)]
+            return inds, [removepad(idx, val, plan, padding) for (idx, val) in zip(inds, data)]
 
         if self.uniform:
             def _unchunk(v):
@@ -263,10 +265,11 @@ class ChunkedArray(object):
         # remove padding
         plan = self.plan
         padding = self.padding
+        removepad = self.removepad
 
         def unpad(record):
             (idx, chunk), value = record
-            return (idx, chunk), self.removepad(chunk, value, plan, padding)
+            return (idx, chunk), removepad(chunk, value, plan, padding)
 
         result._rdd = self._rdd.map(unpad)
 
@@ -459,8 +462,8 @@ class ChunkedArray(object):
         padding: ndarray or array-like
             The padding scheme.
         """
-        starts = array([0 if (i == 0) else p for i, p in zip(idx, self.padding)])
-        slices = [slice(i, i+s) for i, s in zip(starts, self.plan)]
+        starts = array([0 if (i == 0) else p for i, p in zip(idx, padding)])
+        slices = [slice(i, i+s) for i, s in zip(starts, plan)]
         return value[slices]
 
     @staticmethod

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -353,7 +353,7 @@ class ChunkedArray(object):
 
         if missing > 0:
             # the function dropped a dimension
-            #  add new empty dimensions so that unchunking will work
+            # add new empty dimensions so that unchunking will work
             mapfunc = lambda v: iterexpand(func(v), missing)
             xtest = mapfunc(x)
         else:
@@ -482,7 +482,6 @@ class ChunkedArray(object):
         stops = [None if (i == n-1 or not m) else -p for (i, m, p, n) in zip(idx, mask, padding, number)]
         slices = [slice(i1, i2) for (i1, i2) in zip(starts, stops)]
 
-        return idx, slices
         return value[slices]
 
     @staticmethod
@@ -613,5 +612,10 @@ class ChunkedArray(object):
             string = string[:newlines[-2]+1]
             string += "shape: %s\n" % str(self.shape[:-1])
         string += "chunk size: %s\n" % str(tuple(self.plan))
+        if self.padded:
+            string += "padding: %s\n" % str(tuple(self.padding))
+        else:
+            string += "chunk size: none\n"
+
         return string
 

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -116,6 +116,7 @@ def test_padding(sc):
         d = c.map(lambda x: x[:, 0])
 
     c = b.chunk((2,2), padding=1)
+    assert allclose(x, c.unchunk().toarray())
     assert allclose(x, c.keys_to_values((1,)).unchunk().toarray())
     assert allclose(x, c.values_to_keys((0,)).unchunk().toarray())
 

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -4,10 +4,10 @@ from bolt import array, ones
 from bolt.utils import allclose
 
 def test_chunk(sc):
-    
+
     x = arange(4*6).reshape(1, 4, 6)
     b = array(x, sc)
-    
+
     k1, v1 = zip(*b.chunk((2,3))._rdd.sortByKey().collect())
     k2 = tuple(zip(((0,), (0,), (0,), (0,)), ((0, 0), (0, 1), (1, 0), (1, 1))))
     v2 = [s for m in split(x[0], (2,), axis=0) for s in split(m, (3,), axis=1)]
@@ -105,20 +105,25 @@ def test_padding(sc):
     chunks = c.tordd().sortByKey().values().collect()
     assert allclose(chunks[0], array([[0, 1, 2, 3, 4], [6, 7, 8, 9, 10], [12, 13, 14, 15, 16], [18, 19, 20, 21, 22]]))
 
-    with pytest.raises(ValueError):
-        c = b.chunk((2, 2), padding=(3, 1))
-
-    with pytest.raises(ValueError):
-        c = b.chunk((4, 4), padding=(2, 2))
-
-    with pytest.raises(NotImplementedError):
-        c = b.chunk((2, 2), padding=1)
-        d = c.map(lambda x: x[:, 0])
-
     c = b.chunk((2,2), padding=1)
     assert allclose(x, c.unchunk().toarray())
     assert allclose(x, c.keys_to_values((1,)).unchunk().toarray())
     assert allclose(x, c.values_to_keys((0,)).unchunk().toarray())
+
+def test_padding_errors(sc):
+        
+        x = arange(2*2*5*6).reshape(2, 2, 5, 6)
+        b = array(x, sc, (0, 1))
+
+        with pytest.raises(ValueError):
+            c = b.chunk((2, 2), padding=(3, 1))
+
+        with pytest.raises(ValueError):
+            c = b.chunk((4, 4), padding=(2, 2))
+
+        with pytest.raises(NotImplementedError):
+            c = b.chunk((2, 2), padding=1)
+            d = c.map(lambda x: x[:, 0])
 
 def test_map(sc):
 

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -88,6 +88,37 @@ def test_values_to_keys(sc):
     assert allclose(x, c.values_to_keys((0,)).unchunk().toarray())
     assert allclose(x, c.values_to_keys((0, 1)).unchunk().toarray())
 
+
+def test_padding(sc):
+
+    x = arange(2*2*5*6).reshape(2, 2, 5, 6)
+    b = array(x, sc, (0, 1))
+
+    c = b.chunk((2, 2), padding=1)
+    chunks = c.tordd().sortByKey().values().collect()
+    assert allclose(chunks[0], array([[0, 1, 2], [6, 7, 8], [12, 13, 14]]))
+    assert allclose(chunks[1], array([[1, 2, 3, 4], [7, 8, 9, 10], [13, 14, 15, 16]]))
+    assert allclose(chunks[4], array([[7, 8, 9, 10], [13, 14, 15, 16], [19, 20, 21, 22], [25, 26, 27, 28]]))
+    assert allclose(chunks[6], array([[18, 19, 20], [24, 25, 26]]))
+
+    c = b.chunk((3, 3), padding=(1, 2))
+    chunks = c.tordd().sortByKey().values().collect()
+    assert allclose(chunks[0], array([[0, 1, 2, 3, 4], [6, 7, 8, 9, 10], [12, 13, 14, 15, 16], [18, 19, 20, 21, 22]]))
+
+    with pytest.raises(ValueError):
+        c = b.chunk((2, 2), padding=(3, 1))
+
+    with pytest.raises(ValueError):
+        c = b.chunk((4, 4), padding=(2, 2))
+
+    with pytest.raises(NotImplementedError):
+        c = b.chunk((2, 2), padding=1)
+        d = c.map(lambda x: x[:, 0])
+
+    c = b.chunk((2,2), padding=1)
+    assert allclose(x, c.keys_to_values((1,)).unchunk().toarray())
+    assert allclose(x, c.values_to_keys((0,)).unchunk().toarray())
+
 def test_map(sc):
 
     x = arange(4*6).reshape(1, 4, 6)


### PR DESCRIPTION
This PR implements padding for `ChunkedArray`s.

To create a chunked array with padding from a `BoltArraySpark` use the new optional keyword argument `padding`:
`c = b.chunk(size, padding)`
The `padding` argument can be either an integer or an array-like object. If it is an integer, then the amount of padding that it specifies will be added to each chunked dimension (as specified in the `size` argument). If it is an array-like, then it should have the same length as `size` and specify the amount of padding to be used in each chunked dimension.

The amount of padding allowed has two restrictions;
1. The sum of the chunk size and the padding in any dimension cannot exceed the size of that dimension for obvious reasons.
2. The padding size cannot exceed the chunk size in any dimension. This is to prevent padding that includes neighboring chunks and then some -- thus doing more than duplicating the data in the array.

All previous methods on `ChunkedArray` can still be called, with the following behavior:
* `unchunk`: drops padding and behaves as usual
* `keys_to_values`: keys can still be moved to values, even in chunks, but no padding can be added to these new dimensions. If needed, padding these new dimensions could be added in the future.
* `values_to_keys`: drops padding and behaves as usual
* `map`: behaves as usual with the added caveat that the mapped function is not allowed to change the size of the underlying array, as this operation is ambiguous when padding is involved. In the future, we could allow it to drop entire dimensions, if needed.