### PR TITLE
added mixed indexing and bounds checking

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -515,14 +515,15 @@ class BoltArraySpark(BoltArray):
         if isinstance(idx[0], (tuple, list, ndarray)):
             raise ValueError("When mixing basic and advanced indexing, advanced index must be one-dimensional")
 
-        # handle the single advanced index
-        if loc < self.split:    # advanced index is on a key -- filter and update key
+        # single advanced index is on a key -- filter and update key
+        if loc < self.split:
             def newkey(key):
                 newkey = list(key)
                 newkey[loc] = idx.index(key[loc])
                 return tuple(newkey)
             rdd = self._rdd.filter(lambda kv: kv[0][loc] in idx).map(lambda kv: (newkey(kv[0]), kv[1]))
-        else:                   # advanced index is on a value -- use NumPy indexing
+        # single advanced index is on a value -- use NumPy indexing
+        else:
             slices = [slice(0, size) for size in self.shape[self.split:]]
             slices[loc - self.split] = idx
             rdd = self._rdd.map(lambda kv: (kv[0], kv[1][slices]))
@@ -656,7 +657,7 @@ class BoltArraySpark(BoltArray):
         on the Spark bolt array. It exchanges an arbitrary set of axes
         between the keys and the valeus. If either is None, will only
         move axes in one direction (from keys to values, or values to keys).
-        Keys moved to values will be placed immediately after the split; 
+        Keys moved to values will be placed immediately after the split;
         values moved to keys will be placed immediately before the split.
 
         Parameters
@@ -726,7 +727,7 @@ class BoltArraySpark(BoltArray):
         swapping_values = sort(new_keys[new_keys >= split])
         stationary_keys = sort(new_keys[new_keys < split])
         stationary_values = sort(new_values[new_values >= split])
-        
+
         # compute the permutation that the swap causes
         p_swap = r_[stationary_keys, swapping_values, swapping_keys, stationary_values]
 
@@ -740,7 +741,7 @@ class BoltArraySpark(BoltArray):
         arr = self.swap(swapping_keys, swapping_values-split)
         arr = arr.keys.transpose(tuple(p_keys.tolist()))
         arr = arr.values.transpose(tuple(p_values.tolist()))
-        
+
         return arr
 
     @property
@@ -960,5 +961,3 @@ class BoltArraySpark(BoltArray):
         """
         for x in self._rdd.take(10):
             print(x)
-
-

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -576,7 +576,7 @@ class BoltArraySpark(BoltArray):
                 if maxval < 0: maxval = size + maxval
                 # account for over-flowing the bounds
                 if minval < 0: minval = 0
-                if maxval >= size: maxval = size
+                if maxval > size: maxval = size
                 # throw an error if this would lead to an empty dimension in numpy
                 if minval > size-1 or maxval < 1 or minval >= maxval:
                     raise ValueError("Index {} in in dimension {} with shape {} would "

--- a/test/spark/test_spark_getting.py
+++ b/test/spark/test_spark_getting.py
@@ -1,3 +1,4 @@
+import pytest
 from numpy import arange
 from bolt import array, ones
 from bolt.utils import allclose
@@ -78,6 +79,51 @@ def test_getitem_list_array(sc):
 
     b = array(x, sc, axis=(0, 1))
     assert allclose(b[rows, cols, dept].toarray(), x[rows, cols, dept])
+
+def test_getitem_mixed(sc):
+
+    x = arange(4*4*4*4).reshape(4, 4, 4, 4)
+    b = array(x, sc, axis=(0, 1))
+
+    i = [0, 1]
+    s = slice(1, 3)
+    assert allclose(b[i, :, :, :].toarray(), x[i, :, :, :])
+    assert allclose(b[i, s, s, s].toarray(), x[i, s, s, s])
+    assert allclose(b[:, :, i, :].toarray(), x[:, :, i, :])
+    assert allclose(b[s, s, i, s].toarray(), x[s, s, i, s])
+
+    i = [1]
+    assert allclose(b[i, :, :, :].toarray(), x[i, :, :, :])
+    assert allclose(b[:, :, i, :].toarray(), x[:, :, i, :])
+
+    i = [[0, 1], [1, 0]]
+    with pytest.raises(ValueError):
+        b[i, :, :, :]
+
+def test_bounds(sc):
+
+    x = arange(5)
+    b = array(x, sc)
+
+    # out of bounds
+    with pytest.raises(ValueError):
+        b[5]
+
+    with pytest.raises(ValueError):
+        b[-6]
+
+    with pytest.raises(ValueError):
+        b[[1,5]]
+
+    # slicing that would produce an empty dimension
+    with pytest.raises(ValueError):
+        b[3:2]
+
+    with pytest.raises(ValueError):
+        b[5:]
+
+    with pytest.raises(ValueError):
+        b[-6:0]
 
 def test_squeeze(sc):
 


### PR DESCRIPTION
Fixes #75 and #76

Mixed indexing is implemented, but only for the restricted case where only one index uses advanced indexing, while all of the others use basic indexing.

Also adds bounds-checking on indexing so that errors are caught during lazy evaluation. This is implemented such that indexing will either behave identically to NumPy or raise an error if we do not support the particular indexing pattern. Right now there are two such main patterns:
1. The above-mentioned mixed indexing with more than one advanced index
2. Any slicing operation that, in NumPy, would result in an empty dimension (size = 0), as the `BoltArraySpark` is not particularly well-equipped to handle this case at the moment.