### PR TITLE
Chunk map

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -97,8 +97,10 @@ class BoltArraySpark(BoltArray):
         tovalues = [a for a in range(self.split) if a not in axis]
 
         if tokeys or tovalues:
+            print('swapping')
             return self.swap(tovalues, tokeys)
         else:
+            print('no swapping');
             return self
 
     def first(self):

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -368,7 +368,7 @@ class ChunkedArray(object):
 
         rdd = self._rdd.mapValues(check_and_apply)
 
-        vshape = [value_shape[i] if i in unchunked_dims else self.vshape[i] for i in xrange(len(self.vshape))]
+        vshape = [value_shape[i] if i in unchunked_dims else self.vshape[i] for i in range(len(self.vshape))]
         newshape = r_[self.kshape, vshape].astype(int)
 
         return self._constructor(rdd, shape=newshape, plan=value_shape).__finalize__(self)


### PR DESCRIPTION
Updates the `map` function on the `ChunkedArray` object.

The map operation can now only change the shape of a chunk in a single restricted scenario: when the `ChunkedArray` is not padded and the changes in size only happen along non-chunked axes.

For examples of what operations are allowed or not allowed, see the unit tests.