### PR TITLE
added 'sort' options to 'filter'

### DIFF
--- a/test/generic.py
+++ b/test/generic.py
@@ -141,6 +141,13 @@ def filter_suite(arr, b):
     assert res.shape[1:] == b.shape[1:]
     assert res.shape[0] <= b.shape[0]
 
+    # rerun with sorting
+    if not b.mode == "local":
+        filtered = b.filter(lambda x: filter_half(x) < 0.5, sort=True)
+        res = filtered.toarray()
+        assert res.shape[1:] == b.shape[1:]
+        assert res.shape[0] <= b.shape[0]
+
     # filter out half of the values over the second axis
     filtered = b.filter(lambda x: filter_half(x) < 0.5, axis=1)
     res = filtered.toarray()


### PR DESCRIPTION
adds optional kwarg to `BoltArraySpark.filter` to guarantee that the linearized indices computed by `filter` will be ordered by original indices.