### PR TITLE
Multiaxis filter

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -196,9 +196,6 @@ class BoltArraySpark(BoltArray):
         BoltArraySpark
         """
         axis = tupleize(axis)
-        # if len(axis) != 1:
-        #     raise NotImplementedError("Filtering over multiple axes will not be "
-        #                               "supported until SparseBoltArray is implemented.")
 
         swapped = self._align(axis)
         def f(record):

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -196,9 +196,9 @@ class BoltArraySpark(BoltArray):
         BoltArraySpark
         """
         axis = tupleize(axis)
-        if len(axis) != 1:
-            raise NotImplementedError("Filtering over multiple axes will not be "
-                                      "supported until SparseBoltArray is implemented.")
+        # if len(axis) != 1:
+        #     raise NotImplementedError("Filtering over multiple axes will not be "
+        #                               "supported until SparseBoltArray is implemented.")
 
         swapped = self._align(axis)
         def f(record):
@@ -216,7 +216,7 @@ class BoltArraySpark(BoltArray):
         reindexed = zipped.map(lambda kv: (tupleize(kv[1]), kv[0]))
 
         # since we can only filter over one axis, the remaining shape is always the following
-        remaining = list(swapped.shape[1:])
+        remaining = list(swapped.shape[len(axis):])
         if count != 0:
             shape = tuple([count] + remaining)
         else:

--- a/test/generic.py
+++ b/test/generic.py
@@ -161,3 +161,19 @@ def filter_suite(arr, b):
     assert res.shape[0] <= b.shape[2]
     assert res.shape[1] == b.shape[0]
     assert res.shape[2] == b.shape[1]
+
+    # filter all values over the first axis
+    filtered = b.filter(lambda x: False, axis=(0, 1))
+    res = filtered.toarray()
+    assert res.shape == (0,)
+
+    # filter no values over the first axis
+    filtered = b.filter(lambda x: True)
+    res = filtered.toarray()
+    assert res.shape == b.shape
+
+    # filter out half of the values over the first two axes
+    filtered = b.filter(lambda x: filter_half(x) < 0.5, axis=(0, 1))
+    res = filtered.toarray()
+    assert res.shape[0] <= b.shape[0]*b.shape[1]
+    assert res.shape[1] == b.shape[2]


### PR DESCRIPTION
Previously, filtering a `BoltArray` along multiple axes raised a `NotImplementedError`. This PR implements said functionality, which actually only took very minimal changes + adding the appropriate tests.