### PR TITLE
added dtype checking on map in spark mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-version = '0.3.3'
+version = '0.5.0'
 
 setup(
     name='bolt-python',

--- a/test/generic.py
+++ b/test/generic.py
@@ -2,6 +2,7 @@
 Generic tests for all BoltArrays
 """
 from __future__ import print_function
+from numpy import dtype
 from bolt.utils import allclose
 import pytest
 
@@ -67,6 +68,14 @@ def map_suite(arr, b):
         func3 = lambda x: ones(10) if nonuniform_map(x) < 0.5 else ones(5)
         mapped = b.map(func3)
         res = mapped.toarray()
+
+    # check that changes in dtype are correctly handled
+    if b.mode == 'spark':
+        func3 = lambda x: x.astype('float32')
+        mapped = b.map(func3, axis=0)
+        assert mapped.dtype == dtype('float32')
+        mapped = b.map(func3, axis=0, dtype=dtype('float32'))
+        assert mapped.dtype == dtype('float32')
 
 def reduce_suite(arr, b):
     """


### PR DESCRIPTION
Fixes an issues (thanks @sofroniewn for catching this) where mapping simply propagates `dtype` even though the mapped function might very well change this property.

The solution is similar to how map handles functions that might change `shape`:
1. First, allow the user to specify the resulting `dtype` through an optional kwarg. If they do so, then assume they have provided the correct value and run with it.
2. If the user does not supply the kwarg, try applying the function on a test array of the same shape and dtype as a record in the `map` and use the resulting `dtype`.
3. If this fails, as a last resort, do a `first` to find an undeniably legit test array.