### PR TITLE
Updated to indexing

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -489,6 +489,8 @@ class BoltArraySpark(BoltArray):
         if self._split == self.ndim:
             rdd = filtered.map(lambda kv: (key_func(kv[0]), kv[1]))
         else:
+            # handle use of use slice.stop = -1 for a special case (see utils.slicify)
+            value_slices = [s if s.stop != -1 else slice(s.start, None, s.step) for s in value_slices]
             rdd = filtered.map(lambda kv: (key_func(kv[0]), kv[1][value_slices]))
 
         shape = tuple([int(ceil((s.stop - s.start) / float(s.step))) for s in index])

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -573,8 +573,9 @@ class BoltArraySpark(BoltArray):
         barray = self._constructor(rdd, shape=tuple(newshape)).__finalize__(self)
 
         # apply the rest of the simple indices
-        index[loc] = slice(0, None, None)
-        barray = barray[tuple(index)]
+        new_index = index[:]
+        new_index[loc] = slice(0, None, None)
+        barray = barray[tuple(new_index)]
         return barray._rdd, barray.shape, barray.split
 
     def __getitem__(self, index):
@@ -617,7 +618,7 @@ class BoltArraySpark(BoltArray):
         for n, idx in enumerate(index):
             size = self.shape[n]
             if isinstance(idx, (slice, int)):
-                slc = slicify(idx, self.shape[n])
+                slc = slicify(idx, size)
                 # throw an error if this would lead to an empty dimension in numpy
                 if slc.step > 0:
                     minval, maxval = slc.start, slc.stop

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -593,9 +593,12 @@ class BoltArraySpark(BoltArray):
         -------
         BoltSparkArray
         """
-        if isinstance(index, (list, ndarray)):
+        if isinstance(index, tuple):
+            index = list(index)
+        elif isinstance(index, list):
+            pass
+        else:
             index = [index]
-        index = list(tupleize(index))
         int_locs = where([isinstance(i, int) for i in index])[0]
 
         if len(index) > self.ndim:
@@ -623,8 +626,10 @@ class BoltArraySpark(BoltArray):
                                      "produce an empty dimension".format(idx, n, size))
                 index[n] = slc
             else:
-                adjusted = [i + size if i<0 else i for i in array(idx).flatten()]
-                if min(adjusted) < 0 or max(adjusted) > size-1:
+                adjusted = array(idx)
+                inds = where(adjusted<0)
+                adjusted[inds] += size
+                if adjusted.min() < 0 or adjusted.max() > size-1:
                     raise ValueError("Index {} out of bounds in dimension {} with "
                                      "shape {}".format(idx, n, size))
                 index[n] = adjusted

--- a/bolt/utils.py
+++ b/bolt/utils.py
@@ -106,6 +106,11 @@ def slicify(slc, dim):
     """
     Force a slice to have defined start, stop, and step from a known dim.
     Start and stop will always be positive. Step may be negative.
+
+    There is an exception where a negative step overflows the stop needs to have
+    the default value set to -1. This is the only case of a negative start/stop
+    value.
+
     Parameters
     ----------
     slc : slice or int
@@ -128,8 +133,8 @@ def slicify(slc, dim):
             if start < 0: start = 0
             if stop > dim: stop = dim
         else:
-            if stop < 0: stop = 0
-            if start > dim: start = dim
+            if stop < 0: stop = -1
+            if start > dim: start = dim-1
 
         return slice(start, stop, step)
 

--- a/bolt/utils.py
+++ b/bolt/utils.py
@@ -129,7 +129,7 @@ def slicify(slc, dim):
         if start < 0: start += dim
         if stop < 0: stop += dim
         # account for over-flowing the bounds
-        if slc.step > 0:
+        if step > 0:
             if start < 0: start = 0
             if stop > dim: stop = dim
         else:

--- a/test/spark/test_spark_getting.py
+++ b/test/spark/test_spark_getting.py
@@ -5,7 +5,7 @@ from bolt.utils import allclose
 
 
 def test_getitem_slice(sc):
-    x = arange(2*3).reshape((2, 3))
+    x = arange(6*6).reshape((6, 6))
 
     b = array(x, sc, axis=0)
     assert allclose(b[0:1, 0:1].toarray(), x[0:1, 0:1])
@@ -14,6 +14,10 @@ def test_getitem_slice(sc):
     assert allclose(b[0:2, 0:3:2].toarray(), x[0:2, 0:3:2])
     assert allclose(b[:2, :2].toarray(), x[:2, :2])
     assert allclose(b[1:, 1:].toarray(), x[1:, 1:])
+    assert allclose(b[5:1:-1, 5:1:-1].toarray(), x[5:1:-1, 5:1:-1])
+    assert allclose(b[10:-10:-2, 10:-10:-2].toarray(), x[10:-10:-2, 10:-10:-2])
+    assert allclose(b[-5:-1, -5:-1].toarray(), x[-5:-1, -5:-1])
+    assert allclose(b[-1:-5:-2, -1:-5:-2].toarray(), x[-1:-5:-2, -1:-5:-2])
 
     b = array(x, sc, axis=(0, 1))
     assert allclose(b[0:1, 0:1].toarray(), x[0:1, 0:1])
@@ -22,6 +26,10 @@ def test_getitem_slice(sc):
     assert allclose(b[0:2, 0:3:2].toarray(), x[0:2, 0:3:2])
     assert allclose(b[:2, :2].toarray(), x[:2, :2])
     assert allclose(b[1:, 1:].toarray(), x[1:, 1:])
+    assert allclose(b[5:1:-1, 5:1:-1].toarray(), x[5:1:-1, 5:1:-1])
+    assert allclose(b[10:-10:-2, 10:-10:-2].toarray(), x[10:-10:-2, 10:-10:-2])
+    assert allclose(b[-5:-1, -5:-1].toarray(), x[-5:-1, -5:-1])
+    assert allclose(b[-1:-5:-2, -1:-5:-2].toarray(), x[-1:-5:-2, -1:-5:-2])
 
 def test_getitem_slice_ragged(sc):
 
@@ -43,6 +51,7 @@ def test_getitem_int(sc):
     assert allclose(b[1, 2], x[1, 2])
     assert allclose(b[[1], [2]].toarray(), x[[1], [2]])
     assert allclose(b[[1], 2].toarray(), x[[1], 2])
+    assert allclose(b[-1, -2], x[-1, -2])
 
     b = array(x, sc, axis=(0, 1))
     assert allclose(b[0, 0], x[0, 0])
@@ -51,6 +60,7 @@ def test_getitem_int(sc):
     assert allclose(b[1, 2], x[1, 2])
     assert allclose(b[[1], [2]].toarray(), x[[1], [2]])
     assert allclose(b[[1], 2].toarray(), x[[1], 2])
+    assert allclose(b[-1, -2], x[-1, -2])
 
 def test_getitem_list(sc):
 


### PR DESCRIPTION
Addresses #87 

- [x] Indexing with a single iterable to match NumPy: e.g `a[[2,3]]` and `a[(2,3)]`. Why NumPy does what it does in these cases is an interesting topic, but we should match.
- [x] Negative indices for basic indexing: e.g. `a[-1]`, `a[-4:-1]`
- [x] Negative indices for advanced indexing: e.g. `a[:, [-4, -1]]`
- [x] Negative steps for slices: e.g. `a[4:1:-1]` and the slightly mind-bending `a[-1:-4:-1]`
- [x] Update tests for new patterns