### PR TITLE
Map generic

### DIFF
--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -394,7 +394,7 @@ class ChunkedArray(object):
 
         rdd = self._rdd.map(process_record)
 
-        nchunks = self.getnumber(self.plan, self.shape)
+        nchunks = self.getnumber(self.plan, self.vshape)
         newshape = r_[self.kshape, nchunks]
         newsplit = len(self.shape)
         return BoltArraySpark(rdd, shape=newshape, split=newsplit, ordered=False, dtype="object")

--- a/bolt/spark/chunk.py
+++ b/bolt/spark/chunk.py
@@ -315,7 +315,7 @@ class ChunkedArray(object):
 
     def map(self, func, value_shape=None, dtype=None):
         """
-        Apply a function on each subarray.
+        Apply an array -> array function on each subarray.
 
         The function can change the shape of the subarray, but only along
         dimensions that are not chunked.
@@ -379,6 +379,25 @@ class ChunkedArray(object):
         return self._constructor(rdd, shape=tuple(newshape), dtype=dtype,
                                  plan=asarray(value_shape)).__finalize__(self)
 
+    def map_generic(self, func):
+        """
+        Apply a generic array -> object to each subarray
+
+        The resulting object is a BoltArraySpark of dtype object where the
+        blocked dimensions are replaced with indices indication block ID.
+        """
+        def process_record(r):
+            (k, chk), v = r
+            newval = empty(1, dtype="object")
+            newval[0]  = func(v)
+            return k + chk, newval
+
+        rdd = self._rdd.map(process_record)
+
+        nchunks = self.getnumber(self.plan, self.shape)
+        newshape = r_[self.kshape, nchunks]
+        newsplit = len(self.shape)
+        return BoltArraySpark(rdd, shape=newshape, split=newsplit, ordered=False, dtype="object")
 
     def getplan(self, size="150", axes=None, padding=None):
         """

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -1,5 +1,5 @@
 import pytest
-from numpy import arange, split
+from numpy import arange, split, array_equal, empty, newaxis
 from bolt import array, ones
 from bolt.utils import allclose
 
@@ -174,6 +174,21 @@ def test_map_errors(sc):
 
     with pytest.raises(NotImplementedError):
         c.map(f, value_shape=(4,))
+
+def test_map_generic(sc):
+
+    x = arange(2*8*8).reshape(2, 8, 8)
+    b = array(x, sc)
+
+    c = b.chunk(size=(8, 5))
+    d = c.map_generic(lambda x: [0, 1]).toarray()
+
+    truth = empty(2*1*2, dtype=object)
+    for i in range(truth.shape[0]):
+        truth[i] = [0, 1]
+    truth = truth.reshape(2, 1, 2)
+
+    assert array_equal(d, truth)
 
 def test_properties(sc):
 


### PR DESCRIPTION
Implements `ChunkedArray.map_generic`. This function allows the user to apply an arbitrary function to each chunk and returns a `BoltArraySpark` containing the results. The result will have a shape such that dimensions index chunk ID.