### PR TITLE
Unchunk special case

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -598,8 +598,6 @@ class BoltArraySpark(BoltArray):
         """
         if isinstance(index, tuple):
             index = list(index)
-        elif isinstance(index, list):
-            pass
         else:
             index = [index]
         int_locs = where([isinstance(i, int) for i in index])[0]

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -27,6 +27,7 @@ def test_unchunk(sc):
 
     assert allclose(b.chunk((2, 3)).unchunk().toarray(), b.toarray())
     assert allclose(b.chunk((3, 4)).unchunk().toarray(), b.toarray())
+    assert allclose(b.chunk((4, 6)).unchunk().toarray(), b.toarray())
     assert allclose(b.chunk('0.1').unchunk().toarray(), b.toarray())
     assert allclose(b.chunk().unchunk().toarray(), b.toarray())
 

--- a/test/spark/test_spark_getting.py
+++ b/test/spark/test_spark_getting.py
@@ -49,8 +49,11 @@ def test_getitem_int(sc):
     assert allclose(b[0, 1], x[0, 1])
     assert allclose(b[0, 0:1], x[0, 0:1])
     assert allclose(b[1, 2], x[1, 2])
-    assert allclose(b[[1], [2]].toarray(), x[[1], [2]])
-    assert allclose(b[[1], 2].toarray(), x[[1], 2])
+    assert allclose(b[0], x[0])
+    assert allclose(b[[0]], x[[0]])
+    assert allclose(b[(0)], x[(0)])
+    assert allclose(b[[1], [2]], x[[1], [2]])
+    assert allclose(b[[1], 2], x[[1], 2])
     assert allclose(b[-1, -2], x[-1, -2])
 
     b = array(x, sc, axis=(0, 1))
@@ -58,8 +61,11 @@ def test_getitem_int(sc):
     assert allclose(b[0, 1], x[0, 1])
     assert allclose(b[0, 0:1], x[0, 0:1])
     assert allclose(b[1, 2], x[1, 2])
-    assert allclose(b[[1], [2]].toarray(), x[[1], [2]])
-    assert allclose(b[[1], 2].toarray(), x[[1], 2])
+    assert allclose(b[0], x[0])
+    assert allclose(b[[0]], x[[0]])
+    assert allclose(b[(0)], x[(0)])
+    assert allclose(b[[1], [2]], x[[1], [2]])
+    assert allclose(b[[1], 2], x[[1], 2])
     assert allclose(b[-1, -2], x[-1, -2])
 
 def test_getitem_list(sc):


### PR DESCRIPTION
When unchunking a `ChunkedArray`, often a shuffle is required, via a `groupByKey`. However, in special cases, no shuffle is actually required because all of the chunked dimensions have been moved to the keys to that there is really no chunking.

In fact, this is a very common case in Thunder Blocks.

This PR checks for this case and skips the `groupByKey` on `unchunk` when it can be avoided.