### PR TITLE
First after repartition returns the wrong value

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -56,7 +56,7 @@ class BoltArraySpark(BoltArray):
             Number of partitions to repartion the underlying RDD to
         """
 
-        self._rdd.repartition(npartitions=npartitions)
+        self._rdd = self._rdd.repartition(npartitions)
         self._ordered = False
 
     def stack(self, size=None):

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -46,6 +46,19 @@ class BoltArraySpark(BoltArray):
         """
         self._rdd.unpersist()
 
+    def repartition(self, npartitions):
+        """
+        Repartitions the underlying RDD
+
+        Parameters
+        ----------
+        npartitions : int
+            Number of partitions to repartion the underlying RDD to
+        """
+
+        self._rdd.repartition(npartitions=npartitions)
+        self._ordered = False
+
     def stack(self, size=None):
         """
         Aggregates records of a distributed array.
@@ -106,7 +119,8 @@ class BoltArraySpark(BoltArray):
         Return the first element of an array
         """
         from bolt.local.array import BoltArrayLocal
-        return BoltArrayLocal(self._rdd.values().first())
+        rdd = self._rdd if self._ordered else self._rdd.sortByKey()
+        return BoltArrayLocal(rdd.values().first())
 
     def map(self, func, axis=(0,), value_shape=None, dtype=None, with_keys=False):
         """

--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -56,8 +56,8 @@ class BoltArraySpark(BoltArray):
             Number of partitions to repartion the underlying RDD to
         """
 
-        self._rdd = self._rdd.repartition(npartitions)
-        self._ordered = False
+        rdd = self._rdd.repartition(npartitions)
+        return self._constructor(rdd, ordered=False).__finalize__(self)
 
     def stack(self, size=None):
         """

--- a/test/spark/test_spark_basic.py
+++ b/test/spark/test_spark_basic.py
@@ -61,7 +61,7 @@ def test_repartition(sc):
     x = arange(2 * 3).reshape((2, 3))
     b = array(x, sc)
     assert b._ordered
-    b.repartition(10)
+    b = b.repartition(10)
     assert not b._ordered
     assert b._rdd.getNumPartitions() == 10
 

--- a/test/spark/test_spark_basic.py
+++ b/test/spark/test_spark_basic.py
@@ -57,6 +57,14 @@ def test_cache(sc):
     b.unpersist()
     assert not b._rdd.is_cached
 
+def test_repartition(sc):
+    x = arange(2 * 3).reshape((2, 3))
+    b = array(x, sc)
+    assert b._ordered
+    b.repartition(10)
+    assert not b._ordered
+    assert b._rdd.getNumPartitions() == 10
+
 def test_concatenate(sc):
 
     from numpy import concatenate


### PR DESCRIPTION
- Added repartition to bolt spark array
- Added a check in first() that the RDD is ordered