### PR TITLE
shuffle internals upgrade

### DIFF
--- a/bolt/spark/array.py
+++ b/bolt/spark/array.py
@@ -755,9 +755,8 @@ class BoltArraySpark(BoltArray):
 
         from bolt.spark.chunk import ChunkedArray
 
-        c = ChunkedArray(self._rdd, shape=self._shape, split=self._split, dtype=self._dtype)
+        chunks = self.chunk(size)
 
-        chunks = c._chunk(size, axis=vaxes)
         swapped = chunks.keys_to_values(kaxes).values_to_keys([v+len(kaxes) for v in vaxes])
         barray = swapped.unchunk()
 

--- a/test/spark/test_spark_chunking.py
+++ b/test/spark/test_spark_chunking.py
@@ -9,13 +9,13 @@ def test_chunk(sc):
     b = array(x, sc)
 
     k1, v1 = zip(*b.chunk((2,3))._rdd.sortByKey().collect())
-    k2 = tuple(zip(((0,), (0,), (0,), (0,)), ((0, 0), (0, 1), (1, 0), (1, 1))))
+    k2 = ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1))
     v2 = [s for m in split(x[0], (2,), axis=0) for s in split(m, (3,), axis=1)]
     assert k1 == k2
     assert all([allclose(m1, m2) for (m1, m2) in zip(v1, v2)])
 
     k1, v1 = zip(*b.chunk((3,4))._rdd.sortByKey().collect())
-    k2 = tuple(zip(((0,), (0,), (0,), (0,)), ((0, 0), (0, 1), (1, 0), (1, 1))))
+    k2 = ((0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1))
     v2 = [s for m in split(x[0], (3,), axis=0) for s in split(m, (4,), axis=1)]
     assert k1 == k2
     assert all([allclose(m1, m2) for (m1, m2) in zip(v1, v2)])


### PR DESCRIPTION
The current version of Bolt implements shuffles via a lazy `groupByKey`. When `toarray` is called on data that has passed through this `groupByKey`, a `sortByKey` is required before the `collect` to ensure that the records come back in the correct order.

The upside of this approach is that everything is lazy (as opposed to Thunder 0.6 and earlier where the `groupByKey` was immediately followed by the `sortByKey`, which runs a Spark job). The downside is that any computation performed between the `groupByKey` and the `toarray` may be recomputed, once for the `sortByKey` and then again for the `collect`, and the `sortByKey` could cause additional shuffling.

This PR maintains the lazy property of our shuffle-inducing operations while mitigating the downside of the old implementation by using `partitionBy` in place of the `groupByKey`/`sortByKey` pattern. With `partitionBy`, we provide a custom partitioner that simultaneously groups and sorts the records in a lazy fashion. This also provides optimal distribution of the data across executors, reducing skew. All of this leads to some nice performance gains in actual workflows.